### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,18 @@ jobs:
 
       - name: Publish `omgidl-parser` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-parser/v') }}
-        run: yarn workspace @foxglove/omgidl-parser publish
+        run: yarn workspace @foxglove/omgidl-parser publishPublic
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish `omgidl-serialization` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-serialization/v') }}
-        run: yarn workspace @foxglove/omgidl-serialization publish
+        run: yarn workspace @foxglove/omgidl-serialization publishPublic
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish `ros2idl-parser` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/ros2idl-parser/v') }}
-        run: yarn workspace @foxglove/ros2idl-parser publish
+        run: yarn workspace @foxglove/ros2idl-parser publishPublic
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -36,7 +36,7 @@
     "lint:ci": "eslint --report-unused-disable-directives .",
     "prepack": "yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
-    "publish": "yarn publish --access public",
+    "publishPublic": "yarn publish --access public",
     "test": "jest"
   },
   "packageManager": "yarn@3.3.1",

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --report-unused-disable-directives --fix .",
     "prepack": "yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
-    "publish": "yarn publish --access public",
+    "publishPublic": "yarn publish --access public",
     "test": "jest"
   },
   "engines": {

--- a/packages/ros2idl-parser/package.json
+++ b/packages/ros2idl-parser/package.json
@@ -39,7 +39,7 @@
     "lint": "eslint --report-unused-disable-directives --fix .",
     "prepack": "yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
-    "publish": "yarn publish --access public",
+    "publishPublic": "yarn publish --access public",
     "test": "jest"
   },
   "packageManager": "yarn@3.3.1",


### PR DESCRIPTION
Was getting `"publish" script not found` so I added `publishPublic` scripts to each package.
- add publish scripts
- update ci to not use publish params since they're encoded in the package.json script
