### PR TITLE
- use yarn auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,16 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-parser/v') }}
         run: yarn workspace @foxglove/omgidl-parser npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish `omgidl-serialization` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-serialization/v') }}
         run: yarn workspace @foxglove/omgidl-serialization npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Publish `ros2idl-parser` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/ros2idl-parser/v') }}
         run: yarn workspace @foxglove/ros2idl-parser npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
I don't think yarn is recognizing the NODE_AUTH_TOKEN environment variable so we need to use `YARN_NPM_AUTH_TOKEN`