### PR TITLE
Fail on mutable and appendable annotations

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -38,6 +38,10 @@ const keywords = [
   , "unsigned"
   , "short"
   , "long"
+  
+  // Unsupported annotations - will cause errors because annotations use %NAME and not keywords
+  , "mutable"
+  , "appendable"
 ];
 
 const kwObject = keywords.reduce((obj, w) => {

--- a/packages/omgidl-parser/src/parseIdlToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.test.ts
@@ -1293,6 +1293,32 @@ module idl_parser {
       `;
     expect(() => parseIdlToAST(msgDef)).toThrow(/unexpected input/i);
   });
+  /**************** Not yet supported */
+  it("cannot parse extensible type @mutable", () => {
+    const msgDef = `
+      typedef float coord[2];
+      module msg {
+        @mutable
+        struct Point {
+            coord loc;
+        };
+      };
+      `;
+    expect(() => parseIdlToAST(msgDef)).toThrow(/unexpected mutable/i);
+  });
+  it("cannot parse extensible type @appendable", () => {
+    const msgDef = `
+      typedef float coord[2];
+      module msg {
+        @appendable
+        struct Point {
+            coord loc;
+        };
+      };
+      `;
+    expect(() => parseIdlToAST(msgDef)).toThrow(/unexpected appendable/i);
+  });
+
   /****************  Not supported by IDL (as far as I can tell) */
   it("cannot parse constants that reference other constants", () => {
     const msgDef = `

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [

--- a/packages/ros2idl-parser/package.json
+++ b/packages/ros2idl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ros2idl-parser",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Parser for ROS 2 IDL message definitions",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
These are not supported by the serializers yet, so to prevent incorrect reading of data we should fail on schema parsing. 