### PR TITLE
Normalize `Time` schema by changing the `nanosec` field to `nsec`

### DIFF
--- a/packages/ros2idl-parser/package.json
+++ b/packages/ros2idl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ros2idl-parser",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Parser for ROS 2 IDL message definitions",
   "license": "MIT",
   "repository": {

--- a/packages/ros2idl-parser/src/__snapshots__/parse.ros2idl-autoware-large-message.test.ts.snap
+++ b/packages/ros2idl-parser/src/__snapshots__/parse.ros2idl-autoware-large-message.test.ts.snap
@@ -445,7 +445,7 @@ Array [
       },
       Object {
         "isComplex": false,
-        "name": "nanosec",
+        "name": "nsec",
         "type": "uint32",
       },
     ],

--- a/packages/ros2idl-parser/src/parse.ros2idl.test.ts
+++ b/packages/ros2idl-parser/src/parse.ros2idl.test.ts
@@ -879,6 +879,37 @@ module rosidl_parser {
       },
     ]);
   });
+  it("normalizes the builtin_interfaces/msg/Time type for use in studio", () => {
+    const msgDef = `
+    module builtin_interfaces {
+      module msg {
+        struct Time {
+          int32 sec;
+          uint32 nanosec;
+        };
+      };
+    };
+    `;
+
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            isComplex: false,
+            name: "sec",
+            type: "int32",
+          },
+          {
+            isComplex: false,
+            name: "nsec",
+            type: "uint32",
+          },
+        ],
+        name: "builtin_interfaces/msg/Time",
+      },
+    ]);
+  });
   /****************  Not supported by IDL (as far as I can tell) */
   it("cannot parse multiple const declarations in a single line", () => {
     const msgDef = ` 

--- a/packages/ros2idl-parser/src/parseRos2idl.ts
+++ b/packages/ros2idl-parser/src/parseRos2idl.ts
@@ -18,8 +18,13 @@ export function parseRos2idl(messageDefinition: string): MessageDefinition[] {
     for (const field of def.definitions) {
       field.type = normalizeName(field.type);
     }
-    // need to correct the builtin_interfaces/msg/Time nanosec field to nsec so that studio can use it
-    if (def.name === "builtin_interfaces/msg/Time") {
+    // Modify the definition of builtin_interfaces/msg/Time and Duration so they are interpreted as
+    // {sec: number, nsec: number}, compatible with the rest of Studio. The ros2idl builtin types
+    // use "nanosec" instead of "nsec".
+    if (
+      def.name === "builtin_interfaces/msg/Time" ||
+      def.name === "builtin_interfaces/msg/Duration"
+    ) {
       for (const field of def.definitions) {
         if (field.name === "nanosec") {
           field.name = "nsec";

--- a/packages/ros2idl-parser/src/parseRos2idl.ts
+++ b/packages/ros2idl-parser/src/parseRos2idl.ts
@@ -18,6 +18,14 @@ export function parseRos2idl(messageDefinition: string): MessageDefinition[] {
     for (const field of def.definitions) {
       field.type = normalizeName(field.type);
     }
+    // need to correct the builtin_interfaces/msg/Time nanosec field to nsec so that studio can use it
+    if (def.name === "builtin_interfaces/msg/Time") {
+      for (const field of def.definitions) {
+        if (field.name === "nanosec") {
+          field.name = "nsec";
+        }
+      }
+    }
   }
 
   return results;


### PR DESCRIPTION
- normalize `builtin_interfaces/msg/Time` schema for use in studio (nanosec -> nsec)
- update version for deployment