### PR TITLE
Grammar now encodes all annotation info in AST

### DIFF
--- a/packages/omgidl-parser/src/IDLNodeProcessor.ts
+++ b/packages/omgidl-parser/src/IDLNodeProcessor.ts
@@ -118,7 +118,8 @@ export class IDLNodeProcessor {
           constantName,
           nodeScopedIdentifier: scopedIdentifier,
         });
-        // is the node we're currently on
+        // need to make sure we are updating the most up to date node
+        // guaranteed to exist since it's the one we are iterating over
         const possiblyUpdatedNode = this.map.get(scopedIdentifier)!;
         this.map.set(scopedIdentifier, {
           ...possiblyUpdatedNode,

--- a/packages/omgidl-parser/src/IDLNodeProcessor.ts
+++ b/packages/omgidl-parser/src/IDLNodeProcessor.ts
@@ -219,8 +219,18 @@ export class IDLNodeProcessor {
       }
       if (typeNode.declarator === "typedef") {
         // apply typedef definition to struct member
-        const { declarator: _d, name: _name, ...partialDef } = typeNode;
-        this.map.set(scopedIdentifier, { ...node, ...partialDef });
+        const {
+          declarator: _d,
+          name: _name,
+          annotations: typedefAnnotations,
+          ...partialDef
+        } = typeNode;
+
+        this.map.set(scopedIdentifier, {
+          ...node,
+          ...partialDef,
+          annotations: { ...typedefAnnotations, ...node.annotations },
+        });
       } else if (typeNode.declarator === "struct") {
         this.map.set(scopedIdentifier, { ...node, isComplex: true });
       } else {

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -109,18 +109,6 @@ function getIntOrConstantValue(d) {
   return d?.value ? {usesConstant: true, name: d.value} : undefined;
 }
 
-function aggregateConstantUsage(dcl) {
-  const entries = Object.entries(dcl).filter(
-    ([key, value]) => value?.usesConstant === true
-  ).map(([key, {name}]) => ([key, name]));
-  if (entries.length === 0) {
-    return dcl;
-  }
-  return {
-    ...dcl,
-    constantUsage: entries,
-  };
-}
 %}
 
 @lexer lexer
@@ -195,7 +183,7 @@ typedef -> "typedef" (
  | sequenceType fieldName
 ) {% d => {
   const definition = d[1];
-  const astNode = aggregateConstantUsage(extend(definition));
+  const astNode = extend(definition);
   
   return {
     declarator: "typedef",
@@ -212,7 +200,7 @@ fieldWithAnnotation -> multiAnnotations fieldDcl {% d=> {
   const annotations = d[0]
   const fields = d[1];
   const finalDefs = fields.map((def) =>
-    aggregateConstantUsage(extend([annotations, def]))
+    extend([annotations, def])
   );
   return finalDefs;
 } %}
@@ -290,8 +278,7 @@ constType -> (
    | constKeyword booleanType fieldName booleanAssignment simple
    | constKeyword customType fieldName variableAssignment simple
 ) {% d => {
-  const def = aggregateConstantUsage(extend(d[0]));
-  return def;
+  return extend(d[0]);
 } %}
 
 constKeyword -> "const"  {% d => ({isConstant: true, declarator: "const"}) %}

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -96,7 +96,7 @@ function join(d){
 
 // used for combining AST components
 function extend(objs) {
-  return objs.reduce((r, p) => ({ ...r, ...p }), {});
+  return objs.filter(Boolean).reduce((r, p) => ({ ...r, ...p }), {});
 }
 
 function noop() {
@@ -138,10 +138,10 @@ main -> (importDcl:* definition):+ {% d => {
 # support <import> or "import" includes - just ignored
 importDcl -> "#" "include" (%STRING | "<" %NAME ("/" %NAME):* "." "idl" ">") {% noop %}
 
-moduleDcl  -> multiAnnotations "module" fieldName "{" (definition):+ "}" {%
+moduleDcl  -> "module" fieldName "{" (definition):+ "}" {%
 function processModule(d) {
-  const moduleName = d[2].name;
-  const defs = d[4];
+  const moduleName = d[1].name;
+  const defs = d[3];
   // need to return array here to keep same signature as processComplexModule
   return {
     declarator: "module",
@@ -151,27 +151,22 @@ function processModule(d) {
 }
 %}
 
-definition -> (
+definition -> multiAnnotations (
     typeDcl
   | constantDcl
   | moduleDcl
-) semi {% d => d[0][0] %}
+) semi {% d => {
+	const annotations = d[0];
+	const declaration = d[1][0];
+	return extend([annotations, declaration]);
+}%}
 
 typeDcl -> (
-    structWithAnnotations
-  | typedefWithAnnotations
-  | enumWithAnnotations
+    struct
+  | typedef
+  | enum
 ) {% d => d[0][0] %}
 
-structWithAnnotations -> multiAnnotations struct {%
- // default values don't apply to structs so we can just ignore all annotations on structs
- d => d[1]
-%}
-
-enumWithAnnotations -> multiAnnotations enum {%
- // default values don't apply to enums so we can just ignore all annotations on enums
- d => d[1]
-%}
 
 enum ->  "enum" fieldName "{" fieldName ("," fieldName):* "}" {% d => {
   const name = d[1].name;
@@ -198,32 +193,30 @@ struct -> "struct" fieldName "{" (member):+ "}" {% d => {
   };
 } %}
 
-typedefWithAnnotations -> multiAnnotations (
-   typedef allTypes fieldName arrayLength
- | typedef allTypes fieldName
- | typedef sequenceType fieldName
+typedef -> "typedef" (
+   allTypes fieldName arrayLength
+ | allTypes fieldName
+ | sequenceType fieldName
 ) {% d => {
-  const def = aggregateConstantUsage(extend(d.flat(1)));
+  const definition = d[1];
+  const astNode = aggregateConstantUsage(extend(definition));
   
   return {
     declarator: "typedef",
-    ...def,
+    ...astNode,
   };
 } %}
 
-typedef -> "typedef" {% noop %}
-constantDcl -> multiAnnotations constType{% d => d[1] %}
+constantDcl -> constType {% d => d[0] %}
 
 member -> fieldWithAnnotation semi {% d => d[0] %}
 
 fieldWithAnnotation -> multiAnnotations fieldDcl {% d=> {
-  let possibleAnnotations = [];
-  if(d[0]) {
-    possibleAnnotations = d[0];
-  }
+  
+  const annotations = d[0]
   const fields = d[1];
   const finalDefs = fields.map((def) =>
-    aggregateConstantUsage(extend([...possibleAnnotations, def]))
+    aggregateConstantUsage(extend([annotations, def]))
   );
   return finalDefs;
 } %}
@@ -250,28 +243,47 @@ multiFieldNames -> fieldName ("," fieldName):* {%
 
 multiAnnotations -> annotation:* {%
   d => {
-    return d[0] ? d[0].filter(d => d !== null) : null;
+    return d[0].length > 0 ? {annotations: d[0].reduce((record, annotation) => {
+      record[annotation.name] = annotation;
+      return record;
+    }, {}) } : null;
   }
 %}
 
 annotation -> at %NAME ("(" annotationParams ")"):? {% d => {
   const annotationName = d[1].value;
-  if(annotationName === "default") {
-    const params = d[2] ? d[2][1] : {};
-    const defaultValue = params.value;
-    return {defaultValue};
+  const params = d[2] ? d[2][1] : undefined;
+  if(params == undefined) {
+    return { type: 'no-params', name: annotationName };
   }
-  return null
+  // named params in the form of [{<name>: <value>}, ...]
+  if(Array.isArray(params)) {
+    const namedParamsRecord = extend(params);
+    return {
+      type: 'named-params',
+      name: annotationName,
+      namedParams: namedParamsRecord
+    };
+  }
+
+  // can only be constant param
+  return { type: "const-param", value: params, name: annotationName };
 } %}
 
-annotationParams -> (multipleNamedAnnotationParams | literal) {% d => d[0][0] %}
+annotationParams -> (multipleNamedAnnotationParams | constAnnotationParam) {% d => d[0][0] %}
 
-multipleNamedAnnotationParams -> namedAnnotationParams ("," namedAnnotationParams):* {%
-  d => extend([d[0], ...d[1].flatMap(([, param]) => param)])
+multipleNamedAnnotationParams -> namedAnnotationParam ("," namedAnnotationParam):* {%
+  d => ([d[0], ...d[1].flatMap(([, param]) => param)]) // returns array
 %}
 
-namedAnnotationParams -> (%NAME assignment) {% d => ({[d[0][0].value]: d[0][1].value}) %}
- | (%NAME) {% /** constants */ noop %} 
+constAnnotationParam -> %NAME {% d => 
+  // should match `variableAssignment` constant usage structure for consistency
+  // between named and const annotation types
+  ({usesConstant: true, name: d[0].value})
+%}
+ | literal {% d => d[0].value %}
+
+namedAnnotationParam -> (%NAME assignment) {% d => ({[d[0][0].value]: d[0][1].value}) %}
 
 at -> "@" {% noop %}
 
@@ -317,7 +329,15 @@ floatAssignment ->   %EQ (SIGNED_FLOAT | FLOAT) {% ([, num]) => ({valueText: num
 intAssignment -> %EQ (SIGNED_INT | INT) {% ([, num]) => ({valueText: num[0], value: parseInt(num[0])}) %}
 stringAssignment -> %EQ STR {% ([, str]) => ({valueText: str, value: str}) %}
 booleanAssignment -> %EQ BOOLEAN {% ([, bool]) => ({valueText: bool, value: bool === "TRUE"}) %}
-variableAssignment -> %EQ %NAME {% ([, name]) => ({valueText: name.value, value: {usesConstant: true, name: name.value}}) %}
+variableAssignment -> %EQ %NAME {% ([, name]) => 
+  ({
+    valueText: name.value,
+    value: {
+      usesConstant: true,
+      name: name.value
+    }
+  })
+%}
 
 allTypes -> (
     primitiveTypes

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -38,10 +38,6 @@ const keywords = [
   , "unsigned"
   , "short"
   , "long"
-  
-  // Unsupported annotations - will cause errors because annotations use %NAME and not keywords
-  , "mutable"
-  , "appendable"
 ];
 
 const kwObject = keywords.reduce((obj, w) => {

--- a/packages/omgidl-parser/src/parseIdl.test.ts
+++ b/packages/omgidl-parser/src/parseIdl.test.ts
@@ -639,19 +639,6 @@ module rosidl_parser {
     );
     expect(types).toEqual([
       {
-        name: "",
-        definitions: [
-          {
-            name: "UNSIGNED_LONG_CONSTANT",
-            type: "uint32",
-            isConstant: true,
-            isComplex: false,
-            value: 42,
-            valueText: "42",
-          },
-        ],
-      },
-      {
         name: "rosidl_parser::msg::MyMessage",
         definitions: [
           {
@@ -717,6 +704,19 @@ module rosidl_parser {
             isArray: true,
             arrayLength: 23,
             isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "",
+        definitions: [
+          {
+            name: "UNSIGNED_LONG_CONSTANT",
+            type: "uint32",
+            isConstant: true,
+            isComplex: false,
+            value: 42,
+            valueText: "42",
           },
         ],
       },

--- a/packages/omgidl-parser/src/parseIdl.test.ts
+++ b/packages/omgidl-parser/src/parseIdl.test.ts
@@ -1294,6 +1294,39 @@ module rosidl_parser {
       },
     ]);
   });
+  it("prioritizes typedef usage annotations over typedef declaration annotations", () => {
+    const msgDef = `
+    @default(value=2)
+    typedef uint8 byteWithDefault;
+    struct JustACoupleNumbers {
+      byteWithDefault byteWithSameDefault;
+      @default(value=4)
+      byteWithDefault byteWithDifferentDefault;
+    };
+   `;
+
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        name: "JustACoupleNumbers",
+        definitions: [
+          {
+            name: "byteWithSameDefault",
+            type: "uint8",
+            isComplex: false,
+            defaultValue: 2,
+          },
+          {
+            name: "byteWithDifferentDefault",
+            type: "uint8",
+            isComplex: false,
+            defaultValue: 4,
+          },
+        ],
+      },
+    ]);
+  });
+
   // **************** Not supported in our implementation yet
   it("cannot parse typedefs that reference other typedefs", () => {
     const msgDef = `

--- a/packages/omgidl-parser/src/parseIdlToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.test.ts
@@ -352,91 +352,169 @@ module idl_parser {
                   declarator: "struct",
                   definitions: [
                     {
-                      defaultValue: 19000000000,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 19000000000 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_and_frac_with_positive_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 19000000000,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 19000000000 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_and_frac_with_explicit_positive_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 1.1e-10,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 1.1e-10 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_and_frac_with_negative_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 0.00009,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 0.00009 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_and_frac",
                       type: "float",
                     },
                     {
-                      defaultValue: 1,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 1 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_with_empty_frac",
                       type: "float",
                     },
                     {
-                      defaultValue: 0.1,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 0.1 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "frac_only",
                       type: "float",
                     },
                     {
-                      defaultValue: 900000,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 900000 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_with_positive_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 900000,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 900000 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_with_explicit_positive_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 0.00009,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 0.00009 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "int_with_negative_scientific",
                       type: "float",
                     },
                     {
-                      defaultValue: 8.7,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 8.7 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "fixed_int_and_frac",
                       type: "float",
                     },
                     {
-                      defaultValue: 4,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 4 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "fixed_int_with_dot_only",
                       type: "float",
                     },
                     {
-                      defaultValue: 0.3,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 0.3 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "fixed_frac_only",
                       type: "float",
                     },
                     {
-                      defaultValue: 7,
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 7 },
+                        },
+                      },
                       isComplex: false,
                       declarator: "struct-member",
                       name: "fixed_int_only",
@@ -535,48 +613,118 @@ module idl_parser {
     expect(types).toEqual([
       [
         {
+          name: "idl_parser",
           declarator: "module",
           definitions: [
             {
+              name: "msg",
               declarator: "module",
               definitions: [
                 {
+                  name: "MyMessage",
                   declarator: "struct",
+                  annotations: {
+                    verbatim: {
+                      name: "verbatim",
+                      type: "named-params",
+                      namedParams: {
+                        language: "comment",
+                        text: "Documentation of MyMessage.Adjacent string literal.",
+                      },
+                    },
+                    transfer_mode: {
+                      name: "transfer_mode",
+                      type: "const-param",
+                      value: { usesConstant: true, name: "SHMEM_REF" },
+                    },
+                  },
                   definitions: [
                     {
-                      defaultValue: 123,
-                      isComplex: false,
-                      declarator: "struct-member",
                       name: "unsigned_short_value",
+                      isComplex: false,
+                      declarator: "struct-member",
                       type: "unsigned short",
+                      annotations: {
+                        default: {
+                          name: "default",
+                          type: "named-params",
+                          namedParams: { value: 123 },
+                        },
+                      },
                     },
                     {
-                      isComplex: false,
-                      declarator: "struct-member",
                       name: "long_value",
-                      type: "long",
-                    },
-                    {
                       isComplex: false,
                       declarator: "struct-member",
+                      type: "long",
+                      annotations: {
+                        key: {
+                          name: "key",
+                          type: "no-params",
+                        },
+                        range: {
+                          name: "range",
+                          type: "named-params",
+                          namedParams: {
+                            min: -10,
+                            max: 10,
+                          },
+                        },
+                      },
+                    },
+                    {
                       name: "unsigned_long_value",
+                      isComplex: false,
+                      declarator: "struct-member",
                       type: "unsigned long",
+                      annotations: {
+                        verbatim: {
+                          name: "verbatim",
+                          type: "named-params",
+                          namedParams: {
+                            language: "comment",
+                            text: "",
+                          },
+                        },
+                        arbitrary_annotation: {
+                          name: "arbitrary_annotation",
+                          type: "named-params",
+                          namedParams: {
+                            key1: "value1",
+                            key2: true,
+                            key3: 0.0,
+                            key4: 10,
+                          },
+                        },
+                        key: {
+                          name: "key",
+                          type: "no-params",
+                        },
+                      },
                     },
                     {
                       isComplex: false,
                       declarator: "struct-member",
                       name: "uint32_with_default",
                       type: "uint32",
-                      defaultValue: 100,
+                      annotations: {
+                        id: {
+                          name: "id",
+                          type: "const-param",
+                          value: 100,
+                        },
+                        default: {
+                          name: "default",
+                          type: "const-param",
+                          value: 100,
+                        },
+                      },
                     },
                   ],
-                  name: "MyMessage",
                 },
               ],
-              name: "msg",
             },
           ],
-          name: "idl_parser",
         },
       ],
     ]);
@@ -600,9 +748,11 @@ module idl_parser {
     expect(types).toEqual([
       [
         {
+          name: "idl_parser",
           declarator: "module",
           definitions: [
             {
+              name: "action",
               declarator: "module",
               definitions: [
                 {
@@ -614,13 +764,16 @@ module idl_parser {
                   type: "int32",
                 },
                 {
-                  defaultValue: 5,
+                  annotations: {
+                    default: { name: "default", type: "named-params", namedParams: { value: 5 } },
+                  },
                   declarator: "typedef",
                   isComplex: false,
                   name: "shortWithDefault",
                   type: "short",
                 },
                 {
+                  name: "MyAction_Goal",
                   declarator: "struct",
                   definitions: [
                     {
@@ -634,13 +787,10 @@ module idl_parser {
                       type: "shortWithDefault",
                     },
                   ],
-                  name: "MyAction_Goal",
                 },
               ],
-              name: "action",
             },
           ],
-          name: "idl_parser",
         },
       ],
     ]);
@@ -1121,14 +1271,18 @@ module idl_parser {
           declarator: "struct",
           definitions: [
             {
-              defaultValue: 5,
+              annotations: {
+                default: { name: "default", type: "named-params", namedParams: { value: 5 } },
+              },
               isComplex: false,
               declarator: "struct-member",
               name: "int1",
               type: "int32",
             },
             {
-              defaultValue: 5,
+              annotations: {
+                default: { name: "default", type: "named-params", namedParams: { value: 5 } },
+              },
               isComplex: false,
               declarator: "struct-member",
               name: "int2",
@@ -1240,14 +1394,18 @@ module idl_parser {
               declarator: "struct",
               definitions: [
                 {
-                  defaultValue: {
-                    name: "COLORS::GREEN",
-                    usesConstant: true,
+                  annotations: {
+                    default: {
+                      name: "default",
+                      type: "named-params",
+                      namedParams: {
+                        value: { usesConstant: true, name: "COLORS::GREEN" },
+                      },
+                    },
                   },
                   declarator: "struct-member",
                   name: "color",
                   type: "COLORS",
-                  constantUsage: [["defaultValue", "COLORS::GREEN"]],
                 },
               ],
             },

--- a/packages/omgidl-parser/src/parseIdlToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.test.ts
@@ -1135,7 +1135,6 @@ module idl_parser {
                       upperBound: 23,
                     },
                     {
-                      constantUsage: [["upperBound", "UNSIGNED_LONG_CONSTANT"]],
                       isComplex: false,
                       declarator: "struct-member",
                       name: "constant_bounded_wstring_value",
@@ -1385,7 +1384,6 @@ module idl_parser {
                     usesConstant: true,
                   },
                   valueText: "COLORS::RED",
-                  constantUsage: [["value", "COLORS::RED"]],
                 },
               ],
             },

--- a/packages/omgidl-parser/src/parseIdlToAST.unsupported.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.unsupported.test.ts
@@ -40,32 +40,6 @@ describe("Unsupported IDL grammar features", () => {
     expect(() => parseIdlToAST(msgDef)).toThrow();
   });
 
-  it("cannot parse extensible type @mutable", () => {
-    const msgDef = `
-      typedef float coord[2];
-      module msg {
-        @mutable
-        struct Point {
-            coord loc;
-        };
-      };
-      `;
-    expect(() => parseIdlToAST(msgDef)).toThrow(/unexpected mutable/i);
-  });
-
-  it("cannot parse extensible type @appendable", () => {
-    const msgDef = `
-      typedef float coord[2];
-      module msg {
-        @appendable
-        struct Point {
-            coord loc;
-        };
-      };
-      `;
-    expect(() => parseIdlToAST(msgDef)).toThrow(/unexpected appendable/i);
-  });
-
   it("fails forward struct declarations", () => {
     const msgDef = `
       struct Foo;

--- a/packages/omgidl-parser/src/types.ts
+++ b/packages/omgidl-parser/src/types.ts
@@ -28,6 +28,7 @@ export type BaseIDLNode = {
    * This can be used to resolve those string identifiers to their respective values
    */
   constantUsage?: [keyof MessageDefinitionField, string][];
+  annotations?: Record<string, AnyAnnotation>;
 };
 
 /** Node used to represent `module` declarations */
@@ -70,3 +71,22 @@ export interface EnumNode extends BaseIDLNode {
   /** Contained enumerator strings in order of declaration */
   enumerators: string[];
 }
+
+export type AnyAnnotation = AnnotationNamedParams | AnnotationNoParams | AnnotationConstParam;
+export interface BaseAnnotation {
+  type: "no-params" | "named-params" | "const-param";
+  name: string;
+}
+export interface AnnotationNoParams extends BaseAnnotation {
+  type: "no-params";
+}
+export interface AnnotationNamedParams extends BaseAnnotation {
+  type: "named-params";
+  namedParams: Record<string, ConstantValue | ResolveToConstantValue>;
+}
+export interface AnnotationConstParam extends BaseAnnotation {
+  type: "const-param";
+  value: ConstantValue | ResolveToConstantValue;
+}
+
+type ResolveToConstantValue = { usesConstant: true; name: string };

--- a/packages/omgidl-parser/src/types.ts
+++ b/packages/omgidl-parser/src/types.ts
@@ -1,5 +1,15 @@
 import { ConstantValue, MessageDefinitionField } from "@foxglove/message-definition";
 
+type UnresolvedConstantField = Omit<
+  MessageDefinitionField,
+  "arrayLength" | "upperBound" | "arrayUpperBound" | "value"
+> & {
+  arrayLength?: number | ResolveToConstantValue;
+  upperBound?: number | ResolveToConstantValue;
+  arrayUpperBound?: number | ResolveToConstantValue;
+  value?: ConstantValue | ResolveToConstantValue;
+};
+
 export type RawIdlDefinition = DefinitionNode;
 
 /** All possible top-level definitions that can be present in IDL schema */
@@ -22,12 +32,6 @@ export type BaseIDLNode = {
   name: string;
   /** Set to true if Node represents a constant value */
   isConstant?: boolean;
-  /**
-   * Map of a key on a MessageDefinitionField to the string identifier of the constant used in that field
-   * key example: value arrayLength, arrayUpperBound, defaultValue, upperBound
-   * This can be used to resolve those string identifiers to their respective values
-   */
-  constantUsage?: [keyof MessageDefinitionField, string][];
   annotations?: Record<string, AnyAnnotation>;
 };
 
@@ -46,20 +50,19 @@ export interface StructNode extends BaseIDLNode {
 }
 
 /** Node used to represent `const` declarations */
-export interface ConstantNode extends BaseIDLNode, MessageDefinitionField {
+export interface ConstantNode extends BaseIDLNode, UnresolvedConstantField {
   declarator: "const";
   isConstant: true;
-  /** literal value that constant represents */
-  value: ConstantValue;
+  value: ConstantValue | ResolveToConstantValue;
 }
 
 /** Node used to represent `struct-member` declarations */
-export interface StructMemberNode extends BaseIDLNode, MessageDefinitionField {
+export interface StructMemberNode extends BaseIDLNode, UnresolvedConstantField {
   declarator: "struct-member";
 }
 
 /** Node used to represent `typedef` declarations */
-export interface TypeDefNode extends BaseIDLNode, MessageDefinitionField {
+export interface TypeDefNode extends BaseIDLNode, UnresolvedConstantField {
   declarator: "typedef";
   /** Type identifier used in typedef declaration */
   type: string;

--- a/packages/ros2idl-parser/src/__snapshots__/parse.ros2idl-autoware-large-message.test.ts.snap
+++ b/packages/ros2idl-parser/src/__snapshots__/parse.ros2idl-autoware-large-message.test.ts.snap
@@ -10,7 +10,6 @@ Array [
         "type": "std_msgs/msg/Header",
       },
       Object {
-        "arrayUpperBound": undefined,
         "isArray": true,
         "isComplex": true,
         "name": "objects",
@@ -32,7 +31,6 @@ Array [
         "type": "float32",
       },
       Object {
-        "arrayUpperBound": undefined,
         "isArray": true,
         "isComplex": true,
         "name": "classification",
@@ -187,7 +185,6 @@ Array [
   Object {
     "definitions": Array [
       Object {
-        "arrayUpperBound": undefined,
         "isArray": true,
         "isComplex": true,
         "name": "points",
@@ -431,7 +428,6 @@ Array [
         "isComplex": false,
         "name": "frame_id",
         "type": "string",
-        "upperBound": undefined,
       },
     ],
     "name": "std_msgs/msg/Header",

--- a/packages/ros2idl-parser/src/parse.ros2idl.test.ts
+++ b/packages/ros2idl-parser/src/parse.ros2idl.test.ts
@@ -441,19 +441,6 @@ module rosidl_parser {
     );
     expect(types).toEqual([
       {
-        name: "",
-        definitions: [
-          {
-            name: "UNSIGNED_LONG_CONSTANT",
-            type: "uint32",
-            isConstant: true,
-            isComplex: false,
-            value: 42,
-            valueText: "42",
-          },
-        ],
-      },
-      {
         name: "rosidl_parser/msg/MyMessage",
         definitions: [
           {
@@ -513,6 +500,19 @@ module rosidl_parser {
             isArray: true,
             arrayLength: 23,
             isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "",
+        definitions: [
+          {
+            name: "UNSIGNED_LONG_CONSTANT",
+            type: "uint32",
+            isConstant: true,
+            isComplex: false,
+            value: 42,
+            valueText: "42",
           },
         ],
       },


### PR DESCRIPTION
Grammar updated to write all annotation info to AST whereas it only used to write `defaultValue`. Defined a new type on the IDL node to contain this. 

Updated IDLNodeProcessor to resolve `defaultValue` values on outgoing `MessageDefinition`s to the value used in the `default` annotation. This used to be done by the grammar.

Other changes:
 - consolidated where annotations were applied in the grammar to be more consistent.
- Moved top-level constant definitions to the end of the definition array and put them all under a single ""-named definition instead of them all having their own.
- remove constantUsage pattern in favor of doing inside of IDLNodeProcessor