### PR TITLE
Add support for deserializing DDS-XTypes schemas

### DIFF
--- a/packages/omgidl-serialization/README.md
+++ b/packages/omgidl-serialization/README.md
@@ -95,8 +95,10 @@ const uint8Array = writer.writeMessage({
 
 Unsupported:
 
-- `@mutable` and `@appendable` annotations. We do not currently support reading of DHeaders and EMHeaders that would make this possible. Attempting to read messages from schemas that include these annotations may result in data being deserialized incorrectly.
+- `PL_CDR` (XCDR1) - We don't support reading `PL_CDR`headers. Expect for messages to be fail deserialization or be deserialized incorrectly
 - `wchar` and `wstring` - These are written and read using custom implementations that are specific to someone's environment. They are read in by-default as `uint8` chars.
 - `union` types
+
+NOTE: `MessageWriter` does not support writing XCDR2 `PL_CDR2` and `DELIMITED_CDR2` encoded messages. However we can deserialize these encapsulation kinds in `MessageReader`.
 
 Also see the current IDL parser schema limitations [here](../omgidl-parser/README.md#omg-idl-subset-support)

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -48,7 +48,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@foxglove/cdr": "2.1.0",
+    "@foxglove/cdr": "3.0.0",
     "@foxglove/message-definition": "^0.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@foxglove/cdr@npm:2.1.0"
-  checksum: 153632a8911a76d047d896f0a17e12b5a6779465a35790c2fe349efc0eb8a618c877d015a066d8b13a804f0c72131a7e9ca0bf48ed116aa3095a3d7252ab1062
+"@foxglove/cdr@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@foxglove/cdr@npm:3.0.0"
+  checksum: 3ad9b7f92b842aaf8e6f968d0deb060e8cd5b63ee536fce34563bca66d4cb8f488cb03d3b77481a68bbbcbd5fb11e49181575585644046f38401a678218fd589
   languageName: node
   linkType: hard
 
@@ -534,7 +534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": 2.1.0
+    "@foxglove/cdr": 3.0.0
     "@foxglove/message-definition": ^0.2.0
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": 1.2.1


### PR DESCRIPTION
NOTE: This is dependent on this [CDR version](https://github.com/foxglove/cdr/pull/17) that still has yet to be released.

High level notes:
 - Adds logic to determine whether to read dHeaders and emHeaders. This depends on the `CDRReader`'s `uses_Header` and what annotations are present on the complex overarching definition.
 - Another aspect that this logic has to take into account for is the overriding of `sequenceLength` reading when headers are present
 
