### PR TITLE
Add Grammar and Serialization support for multi-dimensional arrays

### DIFF
--- a/packages/omgidl-parser/src/IDLNodeProcessor.ts
+++ b/packages/omgidl-parser/src/IDLNodeProcessor.ts
@@ -8,9 +8,8 @@ import {
   RawIdlDefinition,
   AnyIDLNode,
   ConstantNode,
-  AnnotatedMessageDefinition,
-  AnnotatedMessageDefinitionField,
   IDLMessageDefinition,
+  IDLMessageDefinitionField,
 } from "./types";
 
 const numericTypeMap: Record<string, string> = {
@@ -289,14 +288,14 @@ export class IDLNodeProcessor {
   }
 
   toMessageDefinitions(): MessageDefinition[] {
-    const idlMsgDefs = this.toAnnotatedMessageDefinitions();
+    const idlMsgDefs = this.toIDLMessageDefinitions();
 
     return idlMsgDefs.map(toMessageDefinition);
   }
 
   /** Convert to Message Definitions for serialization and usage in foxglove studio's Raw Message panel. Returned in order of original definitions*/
-  toAnnotatedMessageDefinitions(): AnnotatedMessageDefinition[] {
-    const messageDefinitions: AnnotatedMessageDefinition[] = [];
+  toIDLMessageDefinitions(): IDLMessageDefinition[] {
+    const messageDefinitions: IDLMessageDefinition[] = [];
     const topLevelConstantDefinitions: MessageDefinitionField[] = [];
 
     // flatten for output to message definition
@@ -316,9 +315,9 @@ export class IDLNodeProcessor {
               toScopedIdentifier([namespacedName, typeof def === "string" ? def : def.name]),
             ),
           )
-          .filter(Boolean) as AnnotatedMessageDefinitionField[];
+          .filter(Boolean) as IDLMessageDefinitionField[];
         if (definitionFields.length > 0) {
-          const def: AnnotatedMessageDefinition = {
+          const def: IDLMessageDefinition = {
             name: namespacedName,
             definitions: definitionFields,
           };
@@ -346,7 +345,7 @@ export class IDLNodeProcessor {
 
   private idlNodeToMessageDefinitionField(
     nodeScopedIdentifier: string,
-  ): AnnotatedMessageDefinitionField | undefined {
+  ): IDLMessageDefinitionField | undefined {
     const node = this.map.get(nodeScopedIdentifier);
     if (!node) {
       return undefined;
@@ -379,7 +378,7 @@ export class IDLNodeProcessor {
     const fullMessageDef = {
       ...partialMessageDef,
       type: normalizeType(partialMessageDef.type),
-    } as AnnotatedMessageDefinitionField;
+    } as IDLMessageDefinitionField;
 
     // avoid writing undefined to object fields
     if (arrayLengths != undefined) {

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -178,7 +178,7 @@ struct -> "struct" fieldName "{" (member):+ "}" {% d => {
 } %}
 
 typedef -> "typedef" (
-   allTypes fieldName arrayLength
+   allTypes fieldName arrayLengths
  | allTypes fieldName
  | sequenceType fieldName
 ) {% d => {
@@ -206,7 +206,7 @@ fieldWithAnnotation -> multiAnnotations fieldDcl {% d=> {
 } %}
 
 fieldDcl -> (
-     allTypes  multiFieldNames arrayLength
+     allTypes  multiFieldNames arrayLengths
    | allTypes multiFieldNames
    | sequenceType multiFieldNames
  ) {% (d) => {
@@ -296,8 +296,19 @@ sequenceType -> "sequence" "<" allTypes ("," (INT|%NAME) ):? ">" {% d => {
   };
 }%}
 
+arrayLengths -> arrayLength:+ {%
+	(d) => {
+		const arrInfo = {isArray: true};
+		const arrLengthList = d.flat(2);
+		arrInfo.arrayLengths = arrLengthList.map(
+      ({arrayLength}) => arrayLength
+    );
+		return arrInfo;
+	}
+%}
+
 arrayLength -> "[" (INT|%NAME) "]" {%
-  ([, intOrName]) => ({isArray: true, arrayLength: getIntOrConstantValue(intOrName ? intOrName[0] : undefined) })
+  ([, intOrName]) => ({arrayLength: getIntOrConstantValue(intOrName ? intOrName[0] : undefined) })
 %}
 
 assignment -> (

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -299,16 +299,14 @@ sequenceType -> "sequence" "<" allTypes ("," (INT|%NAME) ):? ">" {% d => {
 arrayLengths -> arrayLength:+ {%
 	(d) => {
 		const arrInfo = {isArray: true};
-		const arrLengthList = d.flat(2);
-		arrInfo.arrayLengths = arrLengthList.map(
-      ({arrayLength}) => arrayLength
-    );
-		return arrInfo;
+		const arrLengthList = d.flat(2).filter((num) => num != undefined);
+		arrInfo.arrayLengths = arrLengthList;
+    return arrInfo;
 	}
 %}
 
 arrayLength -> "[" (INT|%NAME) "]" {%
-  ([, intOrName]) => ({arrayLength: getIntOrConstantValue(intOrName ? intOrName[0] : undefined) })
+  ([, intOrName]) => (getIntOrConstantValue(intOrName ? intOrName[0] : undefined))
 %}
 
 assignment -> (

--- a/packages/omgidl-parser/src/parseIdl.test.ts
+++ b/packages/omgidl-parser/src/parseIdl.test.ts
@@ -102,7 +102,7 @@ describe("omgidl parser tests", () => {
             name: "loc",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
         ],
@@ -128,14 +128,14 @@ describe("omgidl parser tests", () => {
             name: "loc",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
           {
             name: "loc2",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
         ],
@@ -176,63 +176,63 @@ describe("omgidl parser tests", () => {
             name: "layer1L1",
             type: "float32",
             isArray: true,
-            arrayLength: 1,
+            arrayLengths: [1],
             isComplex: false,
           },
           {
             name: "lyr1",
             type: "float32",
             isArray: true,
-            arrayLength: 1,
+            arrayLengths: [1],
             isComplex: false,
           },
           {
             name: "layer1Layer2L2",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
           {
             name: "layer2L2",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
           {
             name: "lyr2",
             type: "float32",
             isArray: true,
-            arrayLength: 2,
+            arrayLengths: [2],
             isComplex: false,
           },
           {
             name: "layer1Layer2Layer3L3",
             type: "float32",
             isArray: true,
-            arrayLength: 3,
+            arrayLengths: [3],
             isComplex: false,
           },
           {
             name: "layer2Layer3L3",
             type: "float32",
             isArray: true,
-            arrayLength: 3,
+            arrayLengths: [3],
             isComplex: false,
           },
           {
             name: "layer3L3",
             type: "float32",
             isArray: true,
-            arrayLength: 3,
+            arrayLengths: [3],
             isComplex: false,
           },
           {
             name: "lyr3",
             type: "float32",
             isArray: true,
-            arrayLength: 3,
+            arrayLengths: [3],
             isComplex: false,
           },
         ],
@@ -711,7 +711,7 @@ module rosidl_parser {
             type: "int16",
             name: "array_short_values",
             isArray: true,
-            arrayLength: 23,
+            arrayLengths: [23],
             isComplex: false,
           },
         ],
@@ -895,7 +895,7 @@ module geometry {
             type: "geometry::msg::Point",
             name: "points_with_length",
             isArray: true,
-            arrayLength: 10,
+            arrayLengths: [10],
             isComplex: true,
           },
           {
@@ -1571,6 +1571,76 @@ module rosidl_parser {
           },
         ],
         name: "JustACoupleNumbers",
+      },
+    ]);
+  });
+
+  it("resolves arrayLengths of typedefs used in structs", () => {
+    const msgDef = `
+    typedef float grid45[4][5];
+    struct BigGrid {
+      grid45 gridLine[1][2][3];
+    };`;
+
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            name: "gridLine",
+            arrayLengths: [1, 2, 3, 4, 5],
+            isArray: true,
+            isComplex: false,
+            type: "float32",
+          },
+        ],
+        name: "BigGrid",
+      },
+    ]);
+  });
+
+  it("resolves multi-dimensional array constant usage", () => {
+    const msgDef = `
+    const uint16 rows = 4;
+    const uint16 cols = 5;
+    struct GridBoard {
+      float grid[rows][cols];
+    };`;
+
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        name: "GridBoard",
+        definitions: [
+          {
+            name: "grid",
+            arrayLengths: [4, 5],
+            isArray: true,
+            isComplex: false,
+            type: "float32",
+          },
+        ],
+      },
+      {
+        name: "",
+        definitions: [
+          {
+            name: "rows",
+            isComplex: false,
+            isConstant: true,
+            type: "uint16",
+            value: 4,
+            valueText: "4",
+          },
+          {
+            name: "cols",
+            isComplex: false,
+            isConstant: true,
+            type: "uint16",
+            value: 5,
+            valueText: "5",
+          },
+        ],
       },
     ]);
   });

--- a/packages/omgidl-parser/src/parseIdl.ts
+++ b/packages/omgidl-parser/src/parseIdl.ts
@@ -2,14 +2,14 @@ import { MessageDefinition } from "@foxglove/message-definition";
 
 import { IDLNodeProcessor } from "./IDLNodeProcessor";
 import { parseIdlToAST } from "./parseIdlToAST";
-import { AnnotatedMessageDefinition } from "./types";
+import { IDLMessageDefinition } from "./types";
 
 /**
- * Parses IDL schema to flattened AnnotatedMessageDefinitions that can be used to serialize/deserialize messages
+ * Parses IDL schema to flattened IDLMessageDefinitions that can be used to serialize/deserialize messages
  * @param messageDefinition - idl decoded message definition string
  * @returns - parsed message definition with annotations
  */
-export function parseIdl(messageDefinition: string): AnnotatedMessageDefinition[] {
+export function parseIdl(messageDefinition: string): IDLMessageDefinition[] {
   const rawIdlDefinitions = parseIdlToAST(messageDefinition);
 
   const idlProcessor = new IDLNodeProcessor(rawIdlDefinitions);
@@ -18,7 +18,7 @@ export function parseIdl(messageDefinition: string): AnnotatedMessageDefinition[
   idlProcessor.resolveTypeDefComplexity();
   idlProcessor.resolveStructMember();
 
-  return idlProcessor.toAnnotatedMessageDefinitions();
+  return idlProcessor.toIDLMessageDefinitions();
 }
 
 /**

--- a/packages/omgidl-parser/src/parseIdl.ts
+++ b/packages/omgidl-parser/src/parseIdl.ts
@@ -14,9 +14,9 @@ export function parseIdl(messageDefinition: string): AnnotatedMessageDefinition[
 
   const idlProcessor = new IDLNodeProcessor(rawIdlDefinitions);
   idlProcessor.resolveEnumTypes();
-  idlProcessor.resolveConstants();
-  idlProcessor.resolveTypeDefs();
-  idlProcessor.resolveStructMemberComplexity();
+  idlProcessor.resolveConstantUsage();
+  idlProcessor.resolveTypeDefComplexity();
+  idlProcessor.resolveStructMember();
 
   return idlProcessor.toAnnotatedMessageDefinitions();
 }
@@ -31,9 +31,9 @@ export function parseIdlToMessageDefinition(messageDefinition: string): MessageD
 
   const idlProcessor = new IDLNodeProcessor(rawIdlDefinitions);
   idlProcessor.resolveEnumTypes();
-  idlProcessor.resolveConstants();
-  idlProcessor.resolveTypeDefs();
-  idlProcessor.resolveStructMemberComplexity();
+  idlProcessor.resolveConstantUsage();
+  idlProcessor.resolveTypeDefComplexity();
+  idlProcessor.resolveStructMember();
 
   return idlProcessor.toMessageDefinitions();
 }

--- a/packages/omgidl-parser/src/parseIdlToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.test.ts
@@ -553,7 +553,7 @@ module idl_parser {
                   },
                   {
                     declarator: "struct-member",
-                    arrayLength: 10,
+                    arrayLengths: [10],
                     isArray: true,
                     name: "points_with_length",
                     type: "geometry::msg::Point",
@@ -1153,7 +1153,7 @@ module idl_parser {
                     upperBound: 3,
                   },
                   {
-                    arrayLength: 23,
+                    arrayLengths: [23],
                     isArray: true,
                     isComplex: false,
                     declarator: "struct-member",
@@ -1397,6 +1397,49 @@ module idl_parser {
         declarator: "typedef",
         isArray: true,
         type: "shortSeq",
+      },
+    ]);
+  });
+
+  it("can parse basic multi-dimensional arrays in typedefs", () => {
+    const msgDef = `
+      typedef float matrix[3][2];
+    `;
+    const types = parseIdlToAST(msgDef);
+
+    expect(types).toEqual([
+      {
+        name: "matrix",
+        arrayLengths: [3, 2],
+        declarator: "typedef",
+        isArray: true,
+        isComplex: false,
+        type: "float",
+      },
+    ]);
+  });
+  it("can parse basic multi-dimensional arrays in struct members", () => {
+    const msgDef = `
+      struct Camera {
+        float matrix[3][2];
+      };
+    `;
+    const types = parseIdlToAST(msgDef);
+
+    expect(types).toEqual([
+      {
+        name: "Camera",
+        declarator: "struct",
+        definitions: [
+          {
+            name: "matrix",
+            arrayLengths: [3, 2],
+            declarator: "struct-member",
+            isArray: true,
+            isComplex: false,
+            type: "float",
+          },
+        ],
       },
     ]);
   });

--- a/packages/omgidl-parser/src/parseIdlToAST.unsupported.test.ts
+++ b/packages/omgidl-parser/src/parseIdlToAST.unsupported.test.ts
@@ -32,14 +32,6 @@ describe("Unsupported IDL grammar features", () => {
     expect(() => parseIdlToAST(msgDef)).toThrow(/union/i);
   });
 
-  it("cannot parse multi-dimensional arrays", () => {
-    const msgDef = `
-      typedef float matrix[3][3];
-    `;
-
-    expect(() => parseIdlToAST(msgDef)).toThrow();
-  });
-
   it("fails forward struct declarations", () => {
     const msgDef = `
       struct Foo;

--- a/packages/omgidl-parser/src/types.ts
+++ b/packages/omgidl-parser/src/types.ts
@@ -106,10 +106,6 @@ export type IDLMessageDefinition = Omit<MessageDefinition, "definitions"> & {
 
 export type IDLMessageDefinitionField = Omit<MessageDefinitionField, "arrayLength"> & {
   annotations?: Record<string, AnyAnnotation>;
-  // multidimensional arrays
+  /** Length of array(s). Outermost arrays are first */
   arrayLengths?: number[];
 };
-
-// Short-sighted type names that are now deprecated
-export type AnnotatedMessageDefinition = IDLMessageDefinition;
-export type AnnotatedMessageDefinitionField = IDLMessageDefinitionField;

--- a/packages/omgidl-parser/src/types.ts
+++ b/packages/omgidl-parser/src/types.ts
@@ -8,10 +8,11 @@ type UnresolvedConstantField = Omit<
   MessageDefinitionField,
   "arrayLength" | "upperBound" | "arrayUpperBound" | "value"
 > & {
-  arrayLength?: number | ResolveToConstantValue;
   upperBound?: number | ResolveToConstantValue;
   arrayUpperBound?: number | ResolveToConstantValue;
   value?: ConstantValue | ResolveToConstantValue;
+  /** Outermost arrays are first */
+  arrayLengths?: (number | ResolveToConstantValue)[];
 };
 
 export type RawIdlDefinition = DefinitionNode;
@@ -98,11 +99,17 @@ export interface AnnotationConstParam extends BaseAnnotation {
 
 type ResolveToConstantValue = { usesConstant: true; name: string };
 
-export type AnnotatedMessageDefinitionField = MessageDefinitionField & {
+export type IDLMessageDefinition = Omit<MessageDefinition, "definitions"> & {
   annotations?: Record<string, AnyAnnotation>;
+  definitions: IDLMessageDefinitionField[];
 };
 
-export type AnnotatedMessageDefinition = Omit<MessageDefinition, "definitions"> & {
+export type IDLMessageDefinitionField = Omit<MessageDefinitionField, "arrayLength"> & {
   annotations?: Record<string, AnyAnnotation>;
-  definitions: AnnotatedMessageDefinitionField[];
+  // multidimensional arrays
+  arrayLengths?: number[];
 };
+
+// Short-sighted type names that are now deprecated
+export type AnnotatedMessageDefinition = IDLMessageDefinition;
+export type AnnotatedMessageDefinitionField = IDLMessageDefinitionField;

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -187,19 +187,19 @@ describe("MessageReader", () => {
       `struct a {uint8 first[4];};`,
       "a",
       [0x00, 0xff, 0x80, 0x7f],
-      { first: new Uint8Array([0, -1, -128, 127]) },
+      { first: new Uint8Array([0x00, 0xff, 0x80, 0x7f]) },
     ],
     [
       `struct a {uint8 first[2][2];};`,
       "a",
       [0x00, 0xff, 0x80, 0x7f],
-      { first: [new Uint8Array([0, -1]), new Uint8Array([-128, 127])] },
+      { first: [new Uint8Array([0x00, 0xff]), new Uint8Array([0x80, 0x7f])] },
     ],
     [
       `struct a {uint8 first[2][1];};`,
       "a",
       [0xff, 0x80],
-      { first: [new Uint8Array([-1]), new Uint8Array([-128])] },
+      { first: [new Uint8Array([0xff]), new Uint8Array([0x80])] },
     ],
     [
       `struct a {string first[2];};`,
@@ -540,7 +540,7 @@ module builtin_interfaces {
     });
   });
 
-  it("PL_CDR2: reads an empty double (8-byte) array", () => {
+  it("reads an empty double (8-byte) array", () => {
     const msgDef = `
         @mutable
         struct Array {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -190,6 +190,18 @@ describe("MessageReader", () => {
       { first: new Uint8Array([0, -1, -128, 127]) },
     ],
     [
+      `struct a {uint8 first[2][2];};`,
+      "a",
+      [0x00, 0xff, 0x80, 0x7f],
+      { first: [new Uint8Array([0, -1]), new Uint8Array([-128, 127])] },
+    ],
+    [
+      `struct a {uint8 first[2][1];};`,
+      "a",
+      [0xff, 0x80],
+      { first: [new Uint8Array([-1]), new Uint8Array([-128])] },
+    ],
+    [
       `struct a {string first[2];};`,
       "a",
       [...serializeString("one"), ...serializeString("longer string")],

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -527,12 +527,11 @@ module builtin_interfaces {
         [4, 5, 6],
       ],
     };
-    const writer = new CdrWriter({ size: 1028, kind: EncapsulationKind.PL_CDR_LE });
+    const writer = new CdrWriter({ size: 1028, kind: EncapsulationKind.PL_CDR2_LE });
     writer.emHeader(true, 1, data.grid.length * data.grid[0]!.length * 4); // size of grid
     for (const row of data.grid) {
       writer.float32Array(row, false); // do not write length for fixed-size arrays
     }
-    writer.sentinelHeader();
 
     const rootDef = "Grid";
     const reader = new MessageReader(rootDef, parseIdl(msgDef));
@@ -541,10 +540,7 @@ module builtin_interfaces {
     });
   });
 
-  // it("Reads array of complex types", () => {
-  // });
-
-  it("PL_CDR: reads an empty double (8-byte) array", () => {
+  it("PL_CDR2: reads an empty double (8-byte) array", () => {
     const msgDef = `
         @mutable
         struct Array {
@@ -552,14 +548,13 @@ module builtin_interfaces {
         };
     `;
 
-    const writer = new CdrWriter({ size: 256, kind: EncapsulationKind.PL_CDR_LE });
+    const writer = new CdrWriter({ size: 256, kind: EncapsulationKind.PL_CDR2_LE });
     const data = {
       numbers: [],
     };
 
     writer.emHeader(true, 1, data.numbers.length + 4); // writes 4 because the sequence length is after it
     writer.sequenceLength(0);
-    writer.sentinelHeader(); // PL_CDR writes sentinel header at end of structures
 
     const rootDef = "Array";
     const reader = new MessageReader(rootDef, parseIdl(msgDef));

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -182,9 +182,6 @@ export class MessageReader<T = unknown> {
         }
       }
     }
-    if (readMemberHeader) {
-      reader.sentinelHeader();
-    }
     return msg;
   }
 }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -1,9 +1,5 @@
 import { CdrReader } from "@foxglove/cdr";
-import {
-  AnnotatedMessageDefinition,
-  AnnotatedMessageDefinitionField,
-  IDLMessageDefinition,
-} from "@foxglove/omgidl-parser";
+import { IDLMessageDefinition, IDLMessageDefinitionField } from "@foxglove/omgidl-parser";
 
 export type Deserializer = (
   reader: CdrReader,
@@ -273,7 +269,7 @@ function readStringArray(reader: CdrReader, count: number): string[] {
   return array;
 }
 
-function getHeaderNeeds(definition: AnnotatedMessageDefinition): {
+function getHeaderNeeds(definition: IDLMessageDefinition): {
   typeUsesDelimiterHeader: boolean;
   typeUsesMemberHeader: boolean;
 } {
@@ -292,7 +288,7 @@ function getHeaderNeeds(definition: AnnotatedMessageDefinition): {
   return { typeUsesDelimiterHeader: false, typeUsesMemberHeader: false };
 }
 
-function getDefinitionId(definition: AnnotatedMessageDefinitionField): number | undefined {
+function getDefinitionId(definition: IDLMessageDefinitionField): number | undefined {
   const { annotations } = definition;
 
   if (!annotations) {


### PR DESCRIPTION
 - Grammar now reads all array lengths into an `arrayLengths` array field on the IDLNode
 - Updated IDL node processor to go through and resolve any constant usage in `arrayLengths`
 - `toMessageDefinition` will error on `arrayLengths > 1` because that type does not support multi-dimensional arrays
 - Update `MessageReader` to support reading of multi-dimensional arrays of both primitive types and complex types.