### PR TITLE
Add support for PL_CDRv1

### DIFF
--- a/packages/omgidl-parser/README.md
+++ b/packages/omgidl-parser/README.md
@@ -32,7 +32,6 @@ NOTE: numbers like `7.4.1` refer to sections of the [OMG IDL specification](http
   - Constant expressions
   - unary operators
   - unions and cases
-  - multi-dimensional arrays
   - default value annotation type checking
   - identifiers prefixed with `::` scope
   - `7.2.6.1` - Octal and hexadecimal integers are not supported (`014` and `0xC`)

--- a/packages/omgidl-serialization/README.md
+++ b/packages/omgidl-serialization/README.md
@@ -95,10 +95,9 @@ const uint8Array = writer.writeMessage({
 
 Unsupported:
 
-- `PL_CDR` (XCDR1) - We don't support reading `PL_CDR`headers. Expect for messages to be fail deserialization or be deserialized incorrectly
 - `wchar` and `wstring` - These are written and read using custom implementations that are specific to someone's environment. They are read in by-default as `uint8` chars.
 - `union` types
 
-NOTE: `MessageWriter` does not support writing XCDR2 `PL_CDR2` and `DELIMITED_CDR2` encoded messages. However we can deserialize these encapsulation kinds in `MessageReader`.
+NOTE: `MessageWriter` does not support writing XCDR1 (`PL_CDR`) or XCDR2 (`PL_CDR2`, `DELIMITED_CDR2`) encoded messages. However we can deserialize these encapsulation kinds in `MessageReader`.
 
 Also see the current IDL parser schema limitations [here](../omgidl-parser/README.md#omg-idl-subset-support)

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -48,7 +48,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@foxglove/cdr": "3.0.0",
+    "@foxglove/cdr": "3.1.0",
     "@foxglove/message-definition": "^0.2.0"
   }
 }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -178,6 +178,9 @@ export class MessageReader<T = unknown> {
         }
       }
     }
+    if (readMemberHeader) {
+      reader.sentinelHeader();
+    }
     return msg;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@foxglove/cdr@npm:3.0.0"
-  checksum: 3ad9b7f92b842aaf8e6f968d0deb060e8cd5b63ee536fce34563bca66d4cb8f488cb03d3b77481a68bbbcbd5fb11e49181575585644046f38401a678218fd589
+"@foxglove/cdr@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@foxglove/cdr@npm:3.1.0"
+  checksum: df27e4d1f2f6f4dab2c61a6a8ead7140ae1fbe4007e43b6c6690022f45db3dee838c8323b8aaf1660c8a9cc5da831f71f93bfbd2f18d94c12d0d2a8716420e47
   languageName: node
   linkType: hard
 
@@ -534,7 +534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": 3.0.0
+    "@foxglove/cdr": 3.1.0
     "@foxglove/message-definition": ^0.2.0
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": 1.2.1


### PR DESCRIPTION
Requires CDR update. Then all that's needed is to account for the sentinelHeader at the end of each struct.

Resolves: FG-6434