### PR TITLE
Deserialization support for Unions

### DIFF
--- a/packages/omgidl-parser/src/IDLNodes/IDLNode.ts
+++ b/packages/omgidl-parser/src/IDLNodes/IDLNode.ts
@@ -54,8 +54,11 @@ export abstract class IDLNode<T extends BaseASTNode = BaseASTNode> implements II
   }
 
   /** Gets a constant node under a local-to-this-node or scoped identifier. Fails if not a ConstantNode */
-  protected getConstantNode(identifier: string): IConstantIDLNode {
-    const maybeConstantNode = this.getNode(this.scopePath, identifier);
+  protected getConstantNode(
+    identifier: string,
+    scopePath: string[] = this.scopePath,
+  ): IConstantIDLNode {
+    const maybeConstantNode = this.getNode(scopePath, identifier);
     if (maybeConstantNode.declarator !== "const") {
       throw new Error(`Expected ${this.name} to be a constant in ${this.scopedIdentifier}`);
     }

--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -1912,6 +1912,79 @@ module rosidl_parser {
       },
     ]);
   });
+  it("can parse union that uses unscoped-local enum values from the switch enum", () => {
+    const msgDef = `
+      enum ColorMode {
+        GRAY, RGBA, RGB
+      };
+      union Color switch (ColorMode) {
+          case GRAY:
+            uint8 gray;
+          case RGBA:
+            uint8 rgba[4];
+          default:
+            uint8 rgb[3];
+      };
+    struct ColorSettings {
+        Color chosenColor;
+    };
+      `;
+    const ast = parse(msgDef);
+    expect(ast).toEqual([
+      {
+        name: "ColorMode",
+        aggregatedKind: "module",
+        definitions: [
+          { name: "GRAY", value: 0, type: "uint32", isConstant: true, isComplex: false },
+          { name: "RGBA", value: 1, type: "uint32", isConstant: true, isComplex: false },
+          { name: "RGB", value: 2, type: "uint32", isConstant: true, isComplex: false },
+        ],
+      },
+      {
+        name: "Color",
+        aggregatedKind: "union",
+        switchType: "uint32",
+        cases: [
+          {
+            predicates: [0],
+            type: {
+              isComplex: false,
+              name: "gray",
+              type: "uint8",
+            },
+          },
+          {
+            predicates: [1],
+            type: {
+              arrayLengths: [4],
+              isArray: true,
+              isComplex: false,
+              name: "rgba",
+              type: "uint8",
+            },
+          },
+        ],
+        defaultCase: {
+          arrayLengths: [3],
+          isArray: true,
+          isComplex: false,
+          name: "rgb",
+          type: "uint8",
+        },
+      },
+      {
+        name: "ColorSettings",
+        aggregatedKind: "struct",
+        definitions: [
+          {
+            name: "chosenColor",
+            type: "Color",
+            isComplex: true,
+          },
+        ],
+      },
+    ]);
+  });
   it("can parse union that uses boolean", () => {
     const msgDef = `
     typedef boolean usesColor;

--- a/packages/omgidl-parser/src/types.ts
+++ b/packages/omgidl-parser/src/types.ts
@@ -37,7 +37,7 @@ export type IDLUnionDefinition = IDLAggregatedDefinition & {
   switchType: string;
   cases: Case[];
   /** Resolved default type specification */
-  default?: IDLMessageDefinitionField;
+  defaultCase?: IDLMessageDefinitionField;
 };
 
 /** Case with resolved predicates and type definition */


### PR DESCRIPTION
The message reader can now read union types. I broke out the functionality from the main `readComplexType` function into 4 other methods for specifically reading fields, unions, structs, and aggregate types. 

Also when an enum is the switchType of a union, that allows the cases to refer only to their member enumerators directly without having to namespace them to the type, so I had to update the logic in UnionIDLNode to allow for that.