### PR TITLE
Add support for enum overrides with `@value` annotations

### DIFF
--- a/packages/omgidl-parser/src/IDLNodes/EnumIDLNode.ts
+++ b/packages/omgidl-parser/src/IDLNodes/EnumIDLNode.ts
@@ -16,7 +16,7 @@ export class EnumIDLNode extends IDLNode<EnumASTNode> implements IEnumIDLNode {
 
   private enumeratorNodes(): IConstantIDLNode[] {
     return this.astNode.enumerators.map((enumerator) =>
-      this.getConstantNode(toScopedIdentifier([...this.scopePath, this.name, enumerator])),
+      this.getConstantNode(toScopedIdentifier([...this.scopePath, this.name, enumerator.name])),
     );
   }
 

--- a/packages/omgidl-parser/src/astTypes.ts
+++ b/packages/omgidl-parser/src/astTypes.ts
@@ -84,7 +84,7 @@ export interface TypedefASTNode extends BaseASTNode, UnresolvedField {
 export interface EnumASTNode extends BaseASTNode {
   declarator: "enum";
   /** Contained enumerator strings in order of declaration */
-  enumerators: string[];
+  enumerators: { name: string; annotations?: Record<string, AnyAnnotation> }[];
 }
 
 export type UnresolvedCase = {

--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -210,19 +210,25 @@ caseLabel -> ("case" constExpression ":") {% (d) => d[0][1] %}
  
 elementSpec -> typeDeclarator {% d => d[0] %}
 
-enum ->  "enum" fieldName "{" fieldName ("," fieldName):* "}" {% d => {
+enum ->  "enum" fieldName "{" enumFieldName ("," enumFieldName):* "}" {% d => {
   const name = d[1].name;
-  const firstMember = d[3].name;
+  const firstMember = d[3];
   const members = d[4]
     .flat(2)
-    .map((m) => m?.name)
-    .filter(Boolean);
+    // need to filter out commas
+    .filter(item => Boolean(item) && item.type !== ",");
 
   return {
     declarator: 'enum',
     name,
     enumerators: [firstMember, ...members],
   };
+} %}
+
+enumFieldName -> multiAnnotations fieldName {% d => {
+  const annotations = d[0];
+  const name = d[1];
+  return extend([annotations, name]);
 } %}
 
 struct -> "struct" fieldName "{" (member):+ "}" {% d => {

--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -1506,6 +1506,72 @@ module rosidl_parser {
       },
     ]);
   });
+  it("parses enums with override values", () => {
+    const msgDef = `
+      enum COLORS {
+        @value(50)
+        RED,
+        GREEN,
+        @value(100)
+        BLUE,
+        CYAN,
+        MAGENTA,
+        @value(80)
+        YELLOW
+      };
+    `;
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        name: "COLORS",
+        aggregatedKind: "module",
+        definitions: [
+          {
+            name: "RED",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 50,
+          },
+          {
+            name: "GREEN",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 0,
+          },
+          {
+            name: "BLUE",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 100,
+          },
+          {
+            name: "CYAN",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 1,
+          },
+          {
+            name: "MAGENTA",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 2,
+          },
+          {
+            name: "YELLOW",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 80,
+          },
+        ],
+      },
+    ]);
+  });
   it("parses enums in modules", () => {
     const msgDef = `
     module Scene {

--- a/packages/omgidl-parser/src/parseIDLToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIDLToAST.test.ts
@@ -1278,7 +1278,32 @@ module idl_parser {
       {
         declarator: "enum",
         name: "COLORS",
-        enumerators: ["RED", "GREEN", "BLUE"],
+        enumerators: [{ name: "RED" }, { name: "GREEN" }, { name: "BLUE" }],
+      },
+    ]);
+  });
+  it("parses enums with value overrides", () => {
+    const msgDef = `
+      enum COLORS {
+        RED,
+        @value(5)
+        GREEN,
+        BLUE
+      };
+    `;
+    const types = parseIDLToAST(msgDef);
+    expect(types).toEqual([
+      {
+        declarator: "enum",
+        name: "COLORS",
+        enumerators: [
+          { name: "RED" },
+          {
+            name: "GREEN",
+            annotations: { value: { name: "value", type: "const-param", value: 5 } },
+          },
+          { name: "BLUE" },
+        ],
       },
     ]);
   });
@@ -1301,7 +1326,7 @@ module idl_parser {
           {
             declarator: "enum",
             name: "COLORS",
-            enumerators: ["RED", "GREEN", "BLUE"],
+            enumerators: [{ name: "RED" }, { name: "GREEN" }, { name: "BLUE" }],
           },
         ],
       },
@@ -1330,7 +1355,7 @@ module idl_parser {
       {
         declarator: "enum",
         name: "COLORS",
-        enumerators: ["RED", "GREEN", "BLUE"],
+        enumerators: [{ name: "RED" }, { name: "GREEN" }, { name: "BLUE" }],
       },
       {
         declarator: "module",
@@ -1533,7 +1558,7 @@ module idl_parser {
     expect(ast).toEqual([
       {
         declarator: "enum",
-        enumerators: ["GRAY", "RGBA", "RGB"],
+        enumerators: [{ name: "GRAY" }, { name: "RGBA" }, { name: "RGB" }],
         name: "ColorMode",
       },
       {


### PR DESCRIPTION
Changed enumerators to be read in as `{name, annotations}` objects. Then when building their constant nodes I'm using the `@value` annotations if they're available. Added a few test cases as well.

Resolves:  FG-4810