### PR TITLE
Update package versions

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {
@@ -11,8 +11,10 @@
     "nearley",
     "grammar",
     "parser",
+    "omg",
     "omgidl",
     "idl",
+    "schema",
     "AST",
     "message",
     "definition",

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,12 +1,17 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [
     "mcap",
     "omgidl",
+    "idl",
     "cdr",
+    "xcdr",
+    "xcdr2",
+    "dds",
+    "dds-xtypes",
     "serialization",
     "deserialization",
     "serde"

--- a/packages/ros2idl-parser/package.json
+++ b/packages/ros2idl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ros2idl-parser",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Parser for ROS 2 IDL message definitions",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
`omgidl-parser` major version update: `1.0.0`
 - breaking: `parseIdl` -> `parseIDL`. 
 - breaking: `AnnotatedMessageDefinition` -> `IDLMessageDefinition`
 - breaking: Shape of `IDLMessageDefinition` has changed
 - now supports unions, enum overrides, and multi-dimensional, fixed-size arrays, and fully-resolved typedef and constant usage.

`omgidl-serialization` major version update: `1.0.0`
 - Breaking: now receives `IDLMessageDefinition` that must include `aggregatedKind`
 - now supports reading PL_CDR1 message encoding
 - reads multi-dimensional fixed-size arrays
 - reads union types

`ros2idl` now fully resolves typedef and constant usage, no breaking changes: `0.3.0`
