### PR TITLE
Fix union switch type not being normalized

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {

--- a/packages/omgidl-parser/src/IDLNodes/UnionIDLNode.ts
+++ b/packages/omgidl-parser/src/IDLNodes/UnionIDLNode.ts
@@ -2,7 +2,7 @@ import { IDLNode } from "./IDLNode";
 import { StructMemberIDLNode } from "./StructMemberIDLNode";
 import { AnyIDLNode, IEnumIDLNode, ITypedefIDLNode, IUnionIDLNode } from "./interfaces";
 import { UnionASTNode } from "../astTypes";
-import { INTEGER_TYPES, SIMPLE_TYPES } from "../primitiveTypes";
+import { INTEGER_TYPES, SIMPLE_TYPES, normalizeType } from "../primitiveTypes";
 import { Case, IDLMessageDefinition, IDLMessageDefinitionField } from "../types";
 
 export class UnionIDLNode extends IDLNode<UnionASTNode> implements IUnionIDLNode {
@@ -97,7 +97,7 @@ export class UnionIDLNode extends IDLNode<UnionASTNode> implements IUnionIDLNode
     const annotations = this.annotations;
     return {
       name: this.scopedIdentifier,
-      switchType: this.switchType,
+      switchType: normalizeType(this.switchType),
       cases: this.cases,
       aggregatedKind: "union",
       ...(this.astNode.defaultCase ? { defaultCase: this.defaultCase } : undefined),

--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -2125,7 +2125,7 @@ module rosidl_parser {
     expect(ast).toEqual([
       {
         name: "MyUnion",
-        switchType: "long",
+        switchType: "int32",
         aggregatedKind: "union",
         cases: [
           {
@@ -2194,7 +2194,7 @@ module rosidl_parser {
     expect(ast).toEqual([
       {
         name: "MyTypes::MyUnion",
-        switchType: "long",
+        switchType: "int32",
         aggregatedKind: "union",
         cases: [
           {
@@ -2261,7 +2261,7 @@ module rosidl_parser {
     expect(ast).toEqual([
       {
         name: "MyUnion",
-        switchType: "long",
+        switchType: "int32",
         aggregatedKind: "union",
         cases: [
           {


### PR DESCRIPTION
Union switch type wasn't being normalized, causing the parser to fail. 

Fixes: https://github.com/foxglove/studio/issues/6935