### PR TITLE
Use lengthCode to determine whether to read sequenceLength again

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -50,7 +50,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@foxglove/cdr": "3.1.0",
+    "@foxglove/cdr": "3.2.0",
     "@foxglove/message-definition": "^0.2.0"
   }
 }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -195,7 +195,7 @@ export class MessageReader<T = unknown> {
     if (readMemberHeader) {
       const { id, objectSize: objectSizeBytes, lengthCode } = reader.emHeader();
       emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSizeBytes : undefined;
-      // emHeaderSizeBytes = objectSizeBytes;
+
       // this can help spot misalignments in reading the data
       if (definitionId != undefined && id !== definitionId) {
         throw Error(
@@ -414,6 +414,7 @@ function getCaseForDiscriminator(
   return unionDef.defaultCase;
 }
 
+/** Only length Codes >= 5 should allow for emHeader sizes to be used in place of other integer lengths */
 function useEmHeaderAsLength(lengthCode: number | undefined): boolean {
   return lengthCode != undefined && lengthCode >= 5;
 }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -191,10 +191,11 @@ export class MessageReader<T = unknown> {
   ): unknown {
     const { readMemberHeader, parentName } = emHeaderOptions;
     const definitionId = getDefinitionId(field);
-    let emHeaderSizeBytes = undefined;
+    let emHeaderSizeBytes;
     if (readMemberHeader) {
-      const { id, objectSize: objectSizeBytes } = reader.emHeader();
-      emHeaderSizeBytes = objectSizeBytes;
+      const { id, objectSize: objectSizeBytes, lengthCode } = reader.emHeader();
+      emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSizeBytes : undefined;
+      // emHeaderSizeBytes = objectSizeBytes;
       // this can help spot misalignments in reading the data
       if (definitionId != undefined && id !== definitionId) {
         throw Error(
@@ -236,8 +237,6 @@ export class MessageReader<T = unknown> {
       }
       const headerSpecifiedLength =
         emHeaderSizeBytes != undefined ? Math.floor(emHeaderSizeBytes / typeLength) : undefined;
-      const remainderBytes =
-        emHeaderSizeBytes != undefined ? emHeaderSizeBytes % typeLength : undefined;
 
       if (field.isArray === true) {
         const deser = typedArrayDeserializers.get(field.type);
@@ -261,15 +260,7 @@ export class MessageReader<T = unknown> {
           // last arrayLengths length is handled in deserializer. It returns an array
           return readNestedArray(typedArrayDeserializer, arrayLengths.slice(0, -1), 0);
         } else {
-          // Special case can happen where the emHeader is not divisible by the typeLength and there is a remainder of 4 bytes.
-          // 4 bytes of 0's are printed after the header length
-          // This can happen for 8 byte typeLength types.
-          if (arrayLengths[0] === 0 && remainderBytes === 4) {
-            reader.sequenceLength();
-            return deser(reader, 0);
-          } else {
-            return deser(reader, arrayLengths[0]!);
-          }
+          return deser(reader, arrayLengths[0]!);
         }
       } else {
         const deser = deserializers.get(field.type);
@@ -421,4 +412,8 @@ function getCaseForDiscriminator(
     }
   }
   return unionDef.defaultCase;
+}
+
+function useEmHeaderAsLength(lengthCode: number | undefined): boolean {
+  return lengthCode != undefined && lengthCode >= 5;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@foxglove/cdr@npm:3.1.0"
-  checksum: df27e4d1f2f6f4dab2c61a6a8ead7140ae1fbe4007e43b6c6690022f45db3dee838c8323b8aaf1660c8a9cc5da831f71f93bfbd2f18d94c12d0d2a8716420e47
+"@foxglove/cdr@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@foxglove/cdr@npm:3.2.0"
+  checksum: 1c8497debd32714bbe26724df1dbde783fddd6e8ef2e126df87f10221691419c1d8f1fdfb6dd9fd066408638aaa325d41aa6ccc9d1291c3d3774f2b844c9e546
   languageName: node
   linkType: hard
 
@@ -534,7 +534,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": 3.1.0
+    "@foxglove/cdr": 3.2.0
     "@foxglove/message-definition": ^0.2.0
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": 1.2.1


### PR DESCRIPTION
Depends on: https://github.com/foxglove/cdr/pull/20


In PL_CDR2 lengthCode  value is used to determine whether the size specified by the emHeader can also be used as the array/string/struct length. This enables that capability.
<img width="721" alt="image" src="https://github.com/foxglove/omgidl/assets/10187776/dba861c2-d50c-4db1-a841-b10dfe09c30f">


