### PR TITLE
Make implicit enums follow C++ conventions

### DIFF
--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -1506,7 +1506,49 @@ module rosidl_parser {
       },
     ]);
   });
-  it("parses enums with override values", () => {
+  it("parses enums with only explicit values", () => {
+    const msgDef = `
+      enum COLORS {
+        @value(50)
+        RED,
+        @value(100)
+        BLUE,
+        @value(80)
+        YELLOW
+      };
+    `;
+    const types = parse(msgDef);
+    expect(types).toEqual([
+      {
+        name: "COLORS",
+        aggregatedKind: "module",
+        definitions: [
+          {
+            name: "RED",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 50,
+          },
+          {
+            name: "BLUE",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 100,
+          },
+          {
+            name: "YELLOW",
+            type: "uint32",
+            isComplex: false,
+            isConstant: true,
+            value: 80,
+          },
+        ],
+      },
+    ]);
+  });
+  it("parses enums with implicit and explicit values", () => {
     const msgDef = `
       enum COLORS {
         @value(50)
@@ -1538,7 +1580,7 @@ module rosidl_parser {
             type: "uint32",
             isComplex: false,
             isConstant: true,
-            value: 0,
+            value: 51,
           },
           {
             name: "BLUE",
@@ -1552,14 +1594,14 @@ module rosidl_parser {
             type: "uint32",
             isComplex: false,
             isConstant: true,
-            value: 1,
+            value: 101,
           },
           {
             name: "MAGENTA",
             type: "uint32",
             isComplex: false,
             isConstant: true,
-            value: 2,
+            value: 102,
           },
           {
             name: "YELLOW",

--- a/packages/omgidl-parser/src/processIDL.ts
+++ b/packages/omgidl-parser/src/processIDL.ts
@@ -26,13 +26,21 @@ export function buildMap(definitions: AnyASTNode[]): Map<string, AnyIDLNode> {
       const newNode = makeIDLNode(scopePath, node, idlMap);
       idlMap.set(newNode.scopedIdentifier, newNode);
       if (node.declarator === "enum") {
+        // DDS X-Types spec section 7.3.1.2.1.5: Enumerated Literal Values
         // How C++ does implicit enums is that they will increment after the last explicit enum
         // even if it collides with an existing enum
         // initialize to -1 so that first value is 0
         let prevEnumValue = -1;
         const enumConstants = node.enumerators.map((m) => {
           const enumValue = getValueAnnotation(m.annotations) ?? (++prevEnumValue as ConstantValue);
-          prevEnumValue = enumValue as number;
+          if (typeof enumValue !== "number") {
+            throw new Error(
+              `Enum value, ${enumValue?.toString() ?? "undefined"}, assigned to ${node.name}::${
+                m.name
+              } must be a number`,
+            );
+          }
+          prevEnumValue = enumValue;
           return {
             declarator: "const" as const,
             isConstant: true as const,

--- a/packages/omgidl-parser/src/processIDL.ts
+++ b/packages/omgidl-parser/src/processIDL.ts
@@ -26,15 +26,22 @@ export function buildMap(definitions: AnyASTNode[]): Map<string, AnyIDLNode> {
       const newNode = makeIDLNode(scopePath, node, idlMap);
       idlMap.set(newNode.scopedIdentifier, newNode);
       if (node.declarator === "enum") {
-        let nextImplicitIEnumValue = 0;
-        const enumConstants = node.enumerators.map((m) => ({
-          declarator: "const" as const,
-          isConstant: true as const,
-          name: m.name,
-          type: "unsigned long",
-          value: getValueAnnotation(m.annotations) ?? (nextImplicitIEnumValue++ as ConstantValue),
-          isComplex: false,
-        }));
+        // How C++ does implicit enums is that they will increment after the last explicit enum
+        // even if it collides with an existing enum
+        // initialize to -1 so that first value is 0
+        let prevEnumValue = -1;
+        const enumConstants = node.enumerators.map((m) => {
+          const enumValue = getValueAnnotation(m.annotations) ?? (++prevEnumValue as ConstantValue);
+          prevEnumValue = enumValue as number;
+          return {
+            declarator: "const" as const,
+            isConstant: true as const,
+            name: m.name,
+            type: "unsigned long",
+            value: enumValue,
+            isComplex: false,
+          };
+        });
         for (const constant of enumConstants) {
           const idlConstantNode = new ConstantIDLNode(namePath, constant, idlMap);
           idlMap.set(idlConstantNode.scopedIdentifier, idlConstantNode);


### PR DESCRIPTION
This change makes enums follow the conventions of C++ implicit and explicit enums. 

This behavior is specified in the DDS X-Types doc here: 
<img width="692" alt="image" src="https://github.com/foxglove/omgidl/assets/10187776/99615614-f6e5-4d62-8cd5-a501be461337">


example code I used to test this in C++:
<img width="1451" alt="image" src="https://github.com/foxglove/omgidl/assets/10187776/71407edb-0c62-41ff-9600-7050099eaeb0">

fixes FG-6149