### PR TITLE
Bump @foxglove/cdr from 3.2.0 to 3.2.1

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -50,7 +50,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "@foxglove/cdr": "3.2.0",
+    "@foxglove/cdr": "^3.2.1",
     "@foxglove/message-definition": "^0.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,10 +560,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@foxglove/cdr@npm:3.2.0"
-  checksum: 1c8497debd32714bbe26724df1dbde783fddd6e8ef2e126df87f10221691419c1d8f1fdfb6dd9fd066408638aaa325d41aa6ccc9d1291c3d3774f2b844c9e546
+"@foxglove/cdr@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@foxglove/cdr@npm:3.2.1"
+  checksum: a3412f7ef6aedd2e983d7698d9b9146e27bc19f5d3204e6a19951100d8cc48a056b364e9f1daf7bd28b253a3fd4327bd6658078487eda3a369174f749ed40bec
   languageName: node
   linkType: hard
 
@@ -642,7 +642,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": 3.2.0
+    "@foxglove/cdr": ^3.2.1
     "@foxglove/message-definition": ^0.3.1
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": 1.2.1


### PR DESCRIPTION
### Public-Facing Changes

None

### Description
Bumps `@foxglove/cdr` to 3.2.1 to include https://github.com/foxglove/cdr/pull/22

@snosenzo probably makes sense to add a dependabot configuration file to this repo?