### PR TITLE
Bump package versions

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [

--- a/packages/ros2idl-parser/package.json
+++ b/packages/ros2idl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ros2idl-parser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Parser for ROS 2 IDL message definitions",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
`@foxglove/omgidl-parser` -> 1.0.3
 - fix enum parsing order to match C++
 - allow for union members to have annotations

`@foxglove/omgidl-serialization` -> 1.0.3
 - use new version of CDR reader

`@foxglove/rosidl-parser` ->  0.3.2
 - use new version of CDR reader