### PR TITLE
Improve omgidl deserialization performance

### DIFF
--- a/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
@@ -80,7 +80,7 @@ describe("DeserializationInfoCache", () => {
     });
   });
 
-  it("creates deserialization info for struct with complext fields", () => {
+  it("creates deserialization info for struct with complex fields", () => {
     const deserializationInfoCache = new DeserializationInfoCache([
       TRANSFORM_DEFINITION,
       VECTOR_DEFINITION,
@@ -141,7 +141,7 @@ describe("DeserializationInfoCache", () => {
     });
   });
 
-  it("can build primitive field deserialization info", () => {
+  it("creates deserialization info for primitive field", () => {
     const deserializationInfoCache = new DeserializationInfoCache([]);
     const fieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
       name: "some_field_name",
@@ -153,7 +153,7 @@ describe("DeserializationInfoCache", () => {
     });
   });
 
-  it("can build primitive array field deserialization info", () => {
+  it("creates deserialization info for primitive array field", () => {
     const deserializationInfoCache = new DeserializationInfoCache([]);
     const fieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
       name: "some_array_field",
@@ -172,35 +172,71 @@ describe("DeserializationInfoCache", () => {
     });
   });
 
-  it("can build complex field deserialization info", () => {
+  it("creates deserialization info for complex field", () => {
     const deserializationInfoCache = new DeserializationInfoCache([TIME_DEFINITION]);
     const timeFieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
       isComplex: true,
       name: "time",
       type: "builtin_interfaces::Time",
     });
-    expect(timeFieldDeserInfo.typeDeserInfo).toMatchObject({
-      type: "struct",
-      fields: [
-        {
-          name: "sec",
-          type: "int32",
-          typeDeserInfo: {
-            type: "primitive",
-            typeLength: 4,
-            deserialize: PRIMITIVE_DESERIALIZERS.get("int32"),
+    expect(timeFieldDeserInfo).toMatchObject({
+      name: "time",
+      type: "builtin_interfaces::Time",
+      typeDeserInfo: {
+        type: "struct",
+        fields: [
+          {
+            name: "sec",
+            type: "int32",
+            typeDeserInfo: {
+              type: "primitive",
+              typeLength: 4,
+              deserialize: PRIMITIVE_DESERIALIZERS.get("int32"),
+            },
           },
-        },
-        {
-          name: "nanosec",
-          type: "uint32",
-          typeDeserInfo: {
-            type: "primitive",
-            typeLength: 4,
-            deserialize: PRIMITIVE_DESERIALIZERS.get("uint32"),
+          {
+            name: "nanosec",
+            type: "uint32",
+            typeDeserInfo: {
+              type: "primitive",
+              typeLength: 4,
+              deserialize: PRIMITIVE_DESERIALIZERS.get("uint32"),
+            },
           },
-        },
-      ],
+        ],
+      },
+    });
+  });
+
+  it("creates deserialization info for complex array field", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([VECTOR_DEFINITION]);
+    const timeFieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
+      isComplex: true,
+      isArray: true,
+      name: "vectors",
+      type: "geometry_msgs::msg::Vector3",
+    });
+    expect(timeFieldDeserInfo).toMatchObject({
+      name: "vectors",
+      type: "geometry_msgs::msg::Vector3",
+      isArray: true,
+      typeDeserInfo: {
+        type: "struct",
+        fields: [
+          {
+            name: "x",
+            ...FLOAT64_PRIMITIVE_DESER_INFO,
+          },
+          {
+            name: "y",
+            ...FLOAT64_PRIMITIVE_DESER_INFO,
+          },
+          {
+            name: "z",
+            ...FLOAT64_PRIMITIVE_DESER_INFO,
+          },
+        ],
+      },
     });
   });
 

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
@@ -1,0 +1,219 @@
+import { IDLMessageDefinition } from "@foxglove/omgidl-parser";
+
+import {
+  DeserializationInfoCache,
+  PRIMITIVE_ARRAY_DESERIALIZERS,
+  PRIMITIVE_DESERIALIZERS,
+} from "./DeserializationInfoCache";
+
+const TRANSFORM_DEFINITION: IDLMessageDefinition = {
+  name: "geometry_msgs::msg::Transform",
+  definitions: [
+    { name: "translation", type: "geometry_msgs::msg::Vector3", isComplex: true },
+    { name: "rotation", type: "geometry_msgs::msg::Quaternion", isComplex: true },
+  ],
+  aggregatedKind: "struct",
+};
+const VECTOR_DEFINITION: IDLMessageDefinition = {
+  name: "geometry_msgs::msg::Vector3",
+  definitions: [
+    { name: "x", type: "float64", isComplex: false },
+    { name: "y", type: "float64", isComplex: false },
+    { name: "z", type: "float64", isComplex: false },
+  ],
+  aggregatedKind: "struct",
+};
+const QUATERNION_DEFINITION: IDLMessageDefinition = {
+  name: "geometry_msgs::msg::Quaternion",
+  definitions: [
+    { name: "x", type: "float64", isComplex: false },
+    { name: "y", type: "float64", isComplex: false },
+    { name: "z", type: "float64", isComplex: false },
+    { name: "w", type: "float64", isComplex: false },
+  ],
+  aggregatedKind: "struct",
+};
+const TIME_DEFINITION: IDLMessageDefinition = {
+  name: "builtin_interfaces::Time",
+  definitions: [
+    { name: "sec", type: "int32", isComplex: false },
+    { name: "nanosec", type: "uint32", isComplex: false },
+  ],
+  aggregatedKind: "struct",
+};
+
+const FLOAT64_PRIMITIVE_DESER_INFO = {
+  type: "float64",
+  typeDeserInfo: {
+    type: "primitive",
+    typeLength: 8,
+    deserialize: PRIMITIVE_DESERIALIZERS.get("float64"),
+  },
+};
+
+describe("DeserializationInfoCache", () => {
+  it("creates deserialization info for struct with primitive fields", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([TIME_DEFINITION]);
+    const timeDeserInfo = deserializationInfoCache.getComplexDeserializationInfo(TIME_DEFINITION);
+    expect(timeDeserInfo).toMatchObject({
+      type: "struct",
+      fields: [
+        {
+          name: "sec",
+          type: "int32",
+          typeDeserInfo: {
+            type: "primitive",
+            typeLength: 4,
+            deserialize: PRIMITIVE_DESERIALIZERS.get("int32"),
+          },
+        },
+        {
+          name: "nanosec",
+          type: "uint32",
+          typeDeserInfo: {
+            type: "primitive",
+            typeLength: 4,
+            deserialize: PRIMITIVE_DESERIALIZERS.get("uint32"),
+          },
+        },
+      ],
+    });
+  });
+
+  it("creates deserialization info for struct with complext fields", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([
+      TRANSFORM_DEFINITION,
+      VECTOR_DEFINITION,
+      QUATERNION_DEFINITION,
+    ]);
+    const timeDeserInfo =
+      deserializationInfoCache.getComplexDeserializationInfo(TRANSFORM_DEFINITION);
+    expect(timeDeserInfo).toMatchObject({
+      type: "struct",
+      fields: [
+        {
+          name: "translation",
+          type: "geometry_msgs::msg::Vector3",
+          typeDeserInfo: {
+            type: "struct",
+            fields: [
+              {
+                name: "x",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+              {
+                name: "y",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+              {
+                name: "z",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+            ],
+          },
+        },
+        {
+          name: "rotation",
+          type: "geometry_msgs::msg::Quaternion",
+          typeDeserInfo: {
+            type: "struct",
+            fields: [
+              {
+                name: "x",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+              {
+                name: "y",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+              {
+                name: "z",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+              {
+                name: "w",
+                ...FLOAT64_PRIMITIVE_DESER_INFO,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("can build primitive field deserialization info", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([]);
+    const fieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
+      name: "some_field_name",
+      type: "float64",
+    });
+    expect(fieldDeserInfo).toMatchObject({
+      name: "some_field_name",
+      ...FLOAT64_PRIMITIVE_DESER_INFO,
+    });
+  });
+
+  it("can build primitive array field deserialization info", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([]);
+    const fieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
+      name: "some_array_field",
+      type: "float64",
+      isArray: true,
+    });
+    expect(fieldDeserInfo).toMatchObject({
+      name: "some_array_field",
+      type: "float64",
+      isArray: true,
+      typeDeserInfo: {
+        type: "array-primitive",
+        typeLength: 8,
+        deserialize: PRIMITIVE_ARRAY_DESERIALIZERS.get("float64"),
+      },
+    });
+  });
+
+  it("can build complex field deserialization info", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([TIME_DEFINITION]);
+    const timeFieldDeserInfo = deserializationInfoCache.buildFieldDeserInfo({
+      isComplex: true,
+      name: "time",
+      type: "builtin_interfaces::Time",
+    });
+    expect(timeFieldDeserInfo.typeDeserInfo).toMatchObject({
+      type: "struct",
+      fields: [
+        {
+          name: "sec",
+          type: "int32",
+          typeDeserInfo: {
+            type: "primitive",
+            typeLength: 4,
+            deserialize: PRIMITIVE_DESERIALIZERS.get("int32"),
+          },
+        },
+        {
+          name: "nanosec",
+          type: "uint32",
+          typeDeserInfo: {
+            type: "primitive",
+            typeLength: 4,
+            deserialize: PRIMITIVE_DESERIALIZERS.get("uint32"),
+          },
+        },
+      ],
+    });
+  });
+
+  it("throws if required type definitions are not found", () => {
+    const deserializationInfoCache = new DeserializationInfoCache([TIME_DEFINITION]);
+    expect(() =>
+      deserializationInfoCache.getComplexDeserializationInfo(TRANSFORM_DEFINITION),
+    ).toThrow();
+    expect(() =>
+      deserializationInfoCache.buildFieldDeserInfo({
+        name: "foo",
+        type: "some/unknown_type",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -116,21 +116,28 @@ export class DeserializationInfoCache {
         );
       }
 
-      return {
+      const deserInfo: UnionDeserializationInfo = {
         type: "union",
         ...getHeaderNeeds(definition),
         definition,
         switchTypeDeser,
         switchTypeLength,
       };
+
+      this.#complexDeserializationInfo.set(definition.name ?? "", deserInfo);
+      return deserInfo;
     }
 
     const deserInfo: StructDeserializationInfo = {
       type: "struct",
       ...getHeaderNeeds(definition),
-      fields: definition.definitions
-        .filter((def) => def.isConstant !== true)
-        .map((fieldDef) => this.buildFieldDeserInfo(fieldDef)),
+      fields: definition.definitions.reduce(
+        (fieldsAccum, fieldDef) =>
+          fieldDef.isConstant === true
+            ? fieldsAccum
+            : fieldsAccum.concat(this.buildFieldDeserInfo(fieldDef)),
+        [] as FieldDeserializationInfo[],
+      ),
     };
 
     this.#complexDeserializationInfo.set(definition.name ?? "", deserInfo);

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -1,0 +1,317 @@
+import { CdrReader } from "@foxglove/cdr";
+import {
+  IDLMessageDefinition,
+  IDLMessageDefinitionField,
+  IDLUnionDefinition,
+} from "@foxglove/omgidl-parser";
+
+export type Deserializer = (
+  reader: CdrReader,
+  /**
+   * Optional length only applied for string types as character length.
+   * Prevents reader from reading sequence length again if already read via header.
+   */
+  length?: number,
+) => boolean | number | bigint | string;
+
+export type ArrayDeserializer = (
+  reader: CdrReader,
+  count: number,
+) =>
+  | boolean[]
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | BigInt64Array
+  | BigUint64Array
+  | Float32Array
+  | Float64Array
+  | string[];
+
+export type HeaderOptions = {
+  usesDelimiterHeader: boolean;
+  usesMemberHeader: boolean;
+};
+
+export type PrimitiveDeserializationInfo = {
+  type: "primitive";
+  typeLength: number;
+  deserialize: Deserializer;
+};
+
+export type PrimitiveArrayDeserializationInfo = {
+  type: "array-primitive";
+  typeLength: number;
+  deserialize: ArrayDeserializer;
+};
+
+export type StructDeserializationInfo = HeaderOptions & {
+  type: "struct";
+  fields: FieldDeserializationInfo[];
+};
+
+export type UnionDeserializationInfo = HeaderOptions & {
+  type: "union";
+  switchTypeDeser: Deserializer;
+  switchTypeLength: number;
+  definition: IDLUnionDefinition;
+};
+
+export type ComplexDeserializationInfo = StructDeserializationInfo | UnionDeserializationInfo;
+export type PrimitiveTypeDeserInfo =
+  | PrimitiveDeserializationInfo
+  | PrimitiveArrayDeserializationInfo;
+
+export type FieldDeserializationInfo = {
+  name: string;
+  type: string;
+  typeDeserInfo: ComplexDeserializationInfo | PrimitiveTypeDeserInfo;
+  isArray?: boolean;
+  arrayLengths?: number[];
+  definitionId?: number;
+};
+
+export class DeserializationInfoCache {
+  #definitions: Map<string, IDLMessageDefinition>;
+  #complexDeserializationInfo: Map<string, ComplexDeserializationInfo> = new Map();
+
+  constructor(definitions: IDLMessageDefinition[]) {
+    this.#definitions = new Map<string, IDLMessageDefinition>(
+      definitions.map((def) => [def.name ?? "", def]),
+    );
+  }
+
+  /**
+   * Gets the deserialization info object for a complex definition (struct or union).
+   * If not found in the cache, the deserialization info object will be built (including sub-types)
+   * and added to the cache.
+   *
+   * @param definition Message definition
+   * @returns Deserialization info
+   */
+  public getComplexDeserializationInfo(
+    definition: IDLMessageDefinition,
+  ): ComplexDeserializationInfo {
+    if (definition.aggregatedKind === "module") {
+      throw new Error(`Modules are not used in serialization`);
+    }
+
+    const cached = this.#complexDeserializationInfo.get(definition.name ?? "");
+    if (cached) {
+      return cached;
+    }
+
+    if (definition.aggregatedKind === "union") {
+      const switchTypeDeser = PRIMITIVE_DESERIALIZERS.get(definition.switchType);
+      const switchTypeLength = typeToByteLength(definition.switchType);
+
+      if (switchTypeDeser == undefined || switchTypeLength == undefined) {
+        throw new Error(
+          `Unrecognized primitive type ${definition.switchType} in union ${
+            definition.name ?? "unknown"
+          }`,
+        );
+      }
+
+      return {
+        type: "union",
+        ...getHeaderNeeds(definition),
+        definition,
+        switchTypeDeser,
+        switchTypeLength,
+      };
+    }
+
+    const deserInfo: StructDeserializationInfo = {
+      type: "struct",
+      ...getHeaderNeeds(definition),
+      fields: definition.definitions
+        .filter((def) => def.isConstant !== true)
+        .map((fieldDef) => this.buildFieldDeserInfo(fieldDef)),
+    };
+
+    this.#complexDeserializationInfo.set(definition.name ?? "", deserInfo);
+    return deserInfo;
+  }
+
+  /**
+   * Builds the deserialization info object for a field definition which can be a complex or primitive type.
+   *
+   * @param definition Field definition
+   * @returns Deserialization info
+   */
+  public buildFieldDeserInfo(definition: IDLMessageDefinitionField): FieldDeserializationInfo {
+    const { name, type, isComplex, isArray, arrayLengths } = definition;
+
+    if (isComplex === true) {
+      let typeDeserInfo = this.#complexDeserializationInfo.get(type);
+      if (!typeDeserInfo) {
+        const fieldDefinition = this.#definitions.get(type);
+        if (!fieldDefinition) {
+          throw new Error(`Failed to find definition for type ${type}`);
+        }
+        typeDeserInfo = this.getComplexDeserializationInfo(fieldDefinition);
+      }
+
+      return {
+        name,
+        type,
+        typeDeserInfo,
+        isArray,
+        arrayLengths,
+        definitionId: getDefinitionId(definition),
+      };
+    }
+
+    if (type === "wchar" || type === "wstring") {
+      throw new Error(
+        `'wchar' and 'wstring' types are not supported because they are implementation dependent`,
+      );
+    }
+
+    const deserialize =
+      isArray === true
+        ? PRIMITIVE_ARRAY_DESERIALIZERS.get(type)
+        : PRIMITIVE_DESERIALIZERS.get(type);
+    if (!deserialize) {
+      throw new Error(`Unrecognized primitive type ${type}`);
+    }
+
+    const typeLength = typeToByteLength(type);
+    if (typeLength == undefined) {
+      throw new Error(`Unrecognized primitive type ${type}`);
+    }
+
+    const fieldDeserInfo: PrimitiveTypeDeserInfo =
+      isArray === true
+        ? {
+            type: "array-primitive",
+            deserialize: deserialize as ArrayDeserializer,
+            typeLength,
+          }
+        : {
+            type: "primitive",
+            deserialize: deserialize as Deserializer,
+            typeLength,
+          };
+
+    return {
+      name,
+      type,
+      typeDeserInfo: fieldDeserInfo,
+      isArray,
+      arrayLengths,
+      definitionId: getDefinitionId(definition),
+    };
+  }
+}
+
+function typeToByteLength(type: string): number | undefined {
+  switch (type) {
+    case "bool":
+    case "int8":
+    case "uint8":
+    case "string":
+      return 1;
+    case "int16":
+    case "uint16":
+      return 2;
+    case "int32":
+    case "uint32":
+    case "float32":
+      return 4;
+    case "int64":
+    case "uint64":
+    case "float64":
+      return 8;
+    default:
+      return undefined;
+  }
+}
+
+export const PRIMITIVE_DESERIALIZERS = new Map<string, Deserializer>([
+  ["bool", (reader) => Boolean(reader.int8())],
+  ["int8", (reader) => reader.int8()],
+  ["uint8", (reader) => reader.uint8()],
+  ["int16", (reader) => reader.int16()],
+  ["uint16", (reader) => reader.uint16()],
+  ["int32", (reader) => reader.int32()],
+  ["uint32", (reader) => reader.uint32()],
+  ["int64", (reader) => reader.int64()],
+  ["uint64", (reader) => reader.uint64()],
+  ["float32", (reader) => reader.float32()],
+  ["float64", (reader) => reader.float64()],
+  ["string", (reader, length) => reader.string(length)],
+]);
+
+export const PRIMITIVE_ARRAY_DESERIALIZERS = new Map<string, ArrayDeserializer>([
+  ["bool", readBoolArray],
+  ["int8", (reader, count) => reader.int8Array(count)],
+  ["uint8", (reader, count) => reader.uint8Array(count)],
+  ["int16", (reader, count) => reader.int16Array(count)],
+  ["uint16", (reader, count) => reader.uint16Array(count)],
+  ["int32", (reader, count) => reader.int32Array(count)],
+  ["uint32", (reader, count) => reader.uint32Array(count)],
+  ["int64", (reader, count) => reader.int64Array(count)],
+  ["uint64", (reader, count) => reader.uint64Array(count)],
+  ["float32", (reader, count) => reader.float32Array(count)],
+  ["float64", (reader, count) => reader.float64Array(count)],
+  ["string", readStringArray],
+]);
+
+function readBoolArray(reader: CdrReader, count: number): boolean[] {
+  const array = new Array<boolean>(count);
+  for (let i = 0; i < count; i++) {
+    array[i] = Boolean(reader.int8());
+  }
+  return array;
+}
+
+function readStringArray(reader: CdrReader, count: number): string[] {
+  const array = new Array<string>(count);
+  for (let i = 0; i < count; i++) {
+    array[i] = reader.string();
+  }
+  return array;
+}
+
+function getHeaderNeeds(definition: IDLMessageDefinition): {
+  usesDelimiterHeader: boolean;
+  usesMemberHeader: boolean;
+} {
+  const { annotations } = definition;
+
+  if (!annotations) {
+    return { usesDelimiterHeader: false, usesMemberHeader: false };
+  }
+
+  if ("mutable" in annotations) {
+    return { usesDelimiterHeader: true, usesMemberHeader: true };
+  }
+  if ("appendable" in annotations) {
+    return { usesDelimiterHeader: true, usesMemberHeader: false };
+  }
+  return { usesDelimiterHeader: false, usesMemberHeader: false };
+}
+
+function getDefinitionId(definition: IDLMessageDefinitionField): number | undefined {
+  const { annotations } = definition;
+
+  if (!annotations) {
+    return undefined;
+  }
+
+  if (!("id" in annotations)) {
+    return undefined;
+  }
+
+  const id = annotations.id;
+  if (id != undefined && id.type === "const-param" && typeof id.value === "number") {
+    return id.value;
+  }
+
+  return undefined;
+}

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -417,13 +417,9 @@ module builtin_interfaces {
         };
     `;
 
-    const arr = [0x88, 0x88];
-    const buffer = Uint8Array.from([0, 1, 0, 0, ...arr]);
-
     const rootDef = "Address";
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(() => reader.readMessage(buffer)).toThrow(
+    expect(() => new MessageReader(rootDef, parseIDL(msgDef))).toThrow(
       /'wchar' and 'wstring' types are not supported/i,
     );
   });
@@ -435,13 +431,8 @@ module builtin_interfaces {
         };
     `;
 
-    const arr = [0x80, 0x00, 0x00, 0x00, 0x88, 0x88]; // 4 byte length, 2 byte wchar
-    const buffer = Uint8Array.from([0, 1, 0, 0, ...arr]);
-
     const rootDef = "Address";
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-
-    expect(() => reader.readMessage(buffer)).toThrow(
+    expect(() => new MessageReader(rootDef, parseIDL(msgDef))).toThrow(
       /'wchar' and 'wstring' types are not supported/i,
     );
   });

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -5,77 +5,18 @@ import {
   IDLUnionDefinition,
 } from "@foxglove/omgidl-parser";
 
-export type Deserializer = (
-  reader: CdrReader,
-  /**
-   * Optional length only applied for string types as character length.
-   * Prevents reader from reading sequence length again if already read via header.
-   */
-  length?: number,
-) => boolean | number | bigint | string;
-
-export type ArrayDeserializer = (
-  reader: CdrReader,
-  count: number,
-) =>
-  | boolean[]
-  | Int8Array
-  | Uint8Array
-  | Int16Array
-  | Uint16Array
-  | Int32Array
-  | Uint32Array
-  | BigInt64Array
-  | BigUint64Array
-  | Float32Array
-  | Float64Array
-  | string[];
-
-type HeaderOptions = {
-  usesDelimiterHeader: boolean;
-  usesMemberHeader: boolean;
-};
-
-type PrimitiveDeserializationInfo = {
-  type: "primitive";
-  typeLength: number;
-  deserialize: Deserializer;
-};
-
-type PrimitiveArrayDeserializationInfo = {
-  type: "array-primitive";
-  typeLength: number;
-  deserialize: ArrayDeserializer;
-};
-
-type StructDeserializationInfo = HeaderOptions & {
-  type: "struct";
-  fields: FieldDeserializationInfo[];
-};
-
-type UnionDeserializationInfo = HeaderOptions & {
-  type: "union";
-  switchTypeDeser: Deserializer;
-  switchTypeLength: number;
-  definition: IDLUnionDefinition;
-};
-
-type ComplexDeserializationInfo = StructDeserializationInfo | UnionDeserializationInfo;
-type PrimitiveTypeDeserInfo = PrimitiveDeserializationInfo | PrimitiveArrayDeserializationInfo;
-
-type FieldDeserializationInfo = {
-  name: string;
-  type: string;
-  typeDeserInfo: ComplexDeserializationInfo | PrimitiveTypeDeserInfo;
-  isArray?: boolean;
-  arrayLengths?: number[];
-  definitionId?: number;
-};
+import {
+  ComplexDeserializationInfo,
+  DeserializationInfoCache,
+  FieldDeserializationInfo,
+  HeaderOptions,
+  StructDeserializationInfo,
+  UnionDeserializationInfo,
+} from "./DeserializationInfoCache";
 
 export class MessageReader<T = unknown> {
   rootDeserializationInfo: ComplexDeserializationInfo;
-  definitions: Map<string, IDLMessageDefinition>;
-  complexDeserializationInfo: Map<string, ComplexDeserializationInfo> = new Map();
+  deserializationInfoCache: DeserializationInfoCache;
 
   constructor(rootDefinitionName: string, definitions: IDLMessageDefinition[]) {
     const rootDefinition = definitions.find((def) => def.name === rootDefinitionName);
@@ -84,12 +25,11 @@ export class MessageReader<T = unknown> {
         `Root definition name "${rootDefinitionName}" not found in schema definitions.`,
       );
     }
-    this.definitions = new Map<string, IDLMessageDefinition>(
-      definitions.map((def) => [def.name ?? "", def]),
-    );
 
     // Build the deserialization info tree structure for the root definition.
-    this.rootDeserializationInfo = this.buildComplexDeserializationInfo(rootDefinition);
+    this.deserializationInfoCache = new DeserializationInfoCache(definitions);
+    this.rootDeserializationInfo =
+      this.deserializationInfoCache.getComplexDeserializationInfo(rootDefinition);
   }
 
   // We template on R here for call site type information if the class type information T is not
@@ -189,29 +129,18 @@ export class MessageReader<T = unknown> {
       );
     }
 
-    if (caseDefType.isComplex === true) {
-      const deser = this.complexDeserializationInfo.get(caseDefType.type);
-      if (!deser) {
-        throw new Error(`Deserializer for union type ${caseDefType.type} not found.`);
-      }
-
-      return {
-        [caseDefType.name]: this.readAggregatedType(deser, reader, options, {}),
-      };
-    } else {
-      const primitiveField = this.buildFieldDeserInfo(caseDefType);
-      return {
-        [caseDefType.name]: this.readMemberFieldValue(
-          primitiveField,
-          reader,
-          {
-            readMemberHeader,
-            parentName: deserInfo.definition.name,
-          },
-          options,
-        ),
-      };
-    }
+    const fieldDeserInfo = this.deserializationInfoCache.buildFieldDeserInfo(caseDefType);
+    return {
+      [caseDefType.name]: this.readMemberFieldValue(
+        fieldDeserInfo,
+        reader,
+        {
+          readMemberHeader,
+          parentName: deserInfo.definition.name,
+        },
+        options,
+      ),
+    };
   }
 
   private readMemberFieldValue(
@@ -289,128 +218,6 @@ export class MessageReader<T = unknown> {
     }
   }
 
-  /**
-   * Builds the deserialization info object for a field definition which can be a complex or primitive type.
-   *
-   * @param definition Field definition
-   * @returns Deserialization info
-   */
-  private buildFieldDeserInfo(definition: IDLMessageDefinitionField): FieldDeserializationInfo {
-    const { name, type, isComplex, isArray, arrayLengths } = definition;
-
-    if (isComplex === true) {
-      let typeDeserInfo = this.complexDeserializationInfo.get(type);
-      if (!typeDeserInfo) {
-        const fieldDefinition = this.definitions.get(type);
-        if (!fieldDefinition) {
-          throw new Error(`Failed to find definition for type ${type}`);
-        }
-        typeDeserInfo = this.buildComplexDeserializationInfo(fieldDefinition);
-      }
-
-      return {
-        name,
-        type,
-        typeDeserInfo,
-        isArray,
-        arrayLengths,
-        definitionId: getDefinitionId(definition),
-      };
-    }
-
-    if (type === "wchar" || type === "wstring") {
-      throw new Error(
-        `'wchar' and 'wstring' types are not supported because they are implementation dependent`,
-      );
-    }
-
-    const deserialize =
-      isArray === true ? typedArrayDeserializers.get(type) : deserializers.get(type);
-    if (!deserialize) {
-      throw new Error(`Unrecognized primitive type ${type}`);
-    }
-
-    const typeLength = typeToByteLength(type);
-    if (typeLength == undefined) {
-      throw new Error(`Unrecognized primitive type ${type}`);
-    }
-
-    const fieldDeserInfo: PrimitiveTypeDeserInfo =
-      isArray === true
-        ? {
-            type: "array-primitive",
-            deserialize: deserialize as ArrayDeserializer,
-            typeLength,
-          }
-        : {
-            type: "primitive",
-            deserialize: deserialize as Deserializer,
-            typeLength,
-          };
-
-    return {
-      name,
-      type,
-      typeDeserInfo: fieldDeserInfo,
-      isArray,
-      arrayLengths,
-      definitionId: getDefinitionId(definition),
-    };
-  }
-
-  /**
-   * Builds the deserialization info object for a complex definition (struct or union).
-   * If not found in the cache, deserialization infos of sub-types will be build automatically
-   * and added to the cache.
-   *
-   * @param definition Message definition
-   * @returns Deserialization info
-   */
-  private buildComplexDeserializationInfo(
-    definition: IDLMessageDefinition,
-  ): ComplexDeserializationInfo {
-    if (definition.aggregatedKind === "module") {
-      throw new Error(`Modules are not used in serialization`);
-    }
-
-    const cached = this.complexDeserializationInfo.get(definition.name ?? "");
-    if (cached) {
-      return cached;
-    }
-
-    if (definition.aggregatedKind === "union") {
-      const switchTypeDeser = deserializers.get(definition.switchType);
-      const switchTypeLength = typeToByteLength(definition.switchType);
-
-      if (switchTypeDeser == undefined || switchTypeLength == undefined) {
-        throw new Error(
-          `Unrecognized primitive type ${definition.switchType} in union ${
-            definition.name ?? "unknown"
-          }`,
-        );
-      }
-
-      return {
-        type: "union",
-        ...getHeaderNeeds(definition),
-        definition,
-        switchTypeDeser,
-        switchTypeLength,
-      };
-    }
-
-    const deserInfo: StructDeserializationInfo = {
-      type: "struct",
-      ...getHeaderNeeds(definition),
-      fields: definition.definitions
-        .filter((def) => def.isConstant !== true)
-        .map((fieldDef) => this.buildFieldDeserInfo(fieldDef)),
-    };
-
-    this.complexDeserializationInfo.set(definition.name ?? "", deserInfo);
-    return deserInfo;
-  }
-
   private readComplexNestedArray(
     reader: CdrReader,
     options: HeaderOptions,
@@ -453,113 +260,6 @@ function readNestedArray(deser: () => unknown, arrayLengths: number[], depth: nu
   }
 
   return array;
-}
-
-function typeToByteLength(type: string): number | undefined {
-  switch (type) {
-    case "bool":
-    case "int8":
-    case "uint8":
-    case "string":
-      return 1;
-    case "int16":
-    case "uint16":
-      return 2;
-    case "int32":
-    case "uint32":
-    case "float32":
-      return 4;
-    case "int64":
-    case "uint64":
-    case "float64":
-      return 8;
-    default:
-      return undefined;
-  }
-}
-
-const deserializers = new Map<string, Deserializer>([
-  ["bool", (reader) => Boolean(reader.int8())],
-  ["int8", (reader) => reader.int8()],
-  ["uint8", (reader) => reader.uint8()],
-  ["int16", (reader) => reader.int16()],
-  ["uint16", (reader) => reader.uint16()],
-  ["int32", (reader) => reader.int32()],
-  ["uint32", (reader) => reader.uint32()],
-  ["int64", (reader) => reader.int64()],
-  ["uint64", (reader) => reader.uint64()],
-  ["float32", (reader) => reader.float32()],
-  ["float64", (reader) => reader.float64()],
-  ["string", (reader, length) => reader.string(length)],
-]);
-
-const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
-  ["bool", readBoolArray],
-  ["int8", (reader, count) => reader.int8Array(count)],
-  ["uint8", (reader, count) => reader.uint8Array(count)],
-  ["int16", (reader, count) => reader.int16Array(count)],
-  ["uint16", (reader, count) => reader.uint16Array(count)],
-  ["int32", (reader, count) => reader.int32Array(count)],
-  ["uint32", (reader, count) => reader.uint32Array(count)],
-  ["int64", (reader, count) => reader.int64Array(count)],
-  ["uint64", (reader, count) => reader.uint64Array(count)],
-  ["float32", (reader, count) => reader.float32Array(count)],
-  ["float64", (reader, count) => reader.float64Array(count)],
-  ["string", readStringArray],
-]);
-
-function readBoolArray(reader: CdrReader, count: number): boolean[] {
-  const array = new Array<boolean>(count);
-  for (let i = 0; i < count; i++) {
-    array[i] = Boolean(reader.int8());
-  }
-  return array;
-}
-
-function readStringArray(reader: CdrReader, count: number): string[] {
-  const array = new Array<string>(count);
-  for (let i = 0; i < count; i++) {
-    array[i] = reader.string();
-  }
-  return array;
-}
-
-function getHeaderNeeds(definition: IDLMessageDefinition): {
-  usesDelimiterHeader: boolean;
-  usesMemberHeader: boolean;
-} {
-  const { annotations } = definition;
-
-  if (!annotations) {
-    return { usesDelimiterHeader: false, usesMemberHeader: false };
-  }
-
-  if ("mutable" in annotations) {
-    return { usesDelimiterHeader: true, usesMemberHeader: true };
-  }
-  if ("appendable" in annotations) {
-    return { usesDelimiterHeader: true, usesMemberHeader: false };
-  }
-  return { usesDelimiterHeader: false, usesMemberHeader: false };
-}
-
-function getDefinitionId(definition: IDLMessageDefinitionField): number | undefined {
-  const { annotations } = definition;
-
-  if (!annotations) {
-    return undefined;
-  }
-
-  if (!("id" in annotations)) {
-    return undefined;
-  }
-
-  const id = annotations.id;
-  if (id != undefined && id.type === "const-param" && typeof id.value === "number") {
-    return id.value;
-  }
-
-  return undefined;
 }
 
 function getCaseForDiscriminator(


### PR DESCRIPTION
### Public-Facing Changes

Improve omgidl deserialization performance

### Description
This PR changes the `MessageReader` to build a tree structure of deserialization info objects when constructed. When building this tree, the concrete deserializers as well as other relevant type information are looked up which avoids that this has to be done during the actual deserialization. Further changes include the removal of some temporary closures which reduces some GC time. 

The outcome of these changes is a performance improvement of up to 30% (depends on message type)

![image](https://github.com/foxglove/omgidl/assets/9250155/84e77541-f673-43fd-8c63-4fa0d4bd974f)
In the image above, **left** is this PR, **right** is the currently released version

Resolves FG-6300