### PR TITLE
Add discriminator value to union fields messages

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -2,6 +2,7 @@ import { CdrWriter, EncapsulationKind } from "@foxglove/cdr";
 import { parseIDL } from "@foxglove/omgidl-parser";
 
 import { MessageReader } from "./MessageReader";
+import { UNION_DISCRIMINATOR_PROPERTY_KEY } from "./constants";
 
 const serializeString = (str: string): Uint8Array => {
   const data = Buffer.from(str, "utf8");
@@ -771,6 +772,7 @@ module builtin_interfaces {
 
     expect(msgout).toEqual({
       color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 3,
         gray: 55,
       },
     });
@@ -811,6 +813,7 @@ module builtin_interfaces {
 
     expect(msgout).toEqual({
       color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
         rgb: Uint8Array.from([255, 0, 0]),
       },
     });

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -13,6 +13,7 @@ import {
   StructDeserializationInfo,
   UnionDeserializationInfo,
 } from "./DeserializationInfoCache";
+import { UNION_DISCRIMINATOR_PROPERTY_KEY } from "./constants";
 
 export class MessageReader<T = unknown> {
   rootDeserializationInfo: ComplexDeserializationInfo;
@@ -125,7 +126,9 @@ export class MessageReader<T = unknown> {
     }
 
     const fieldDeserInfo = this.deserializationInfoCache.buildFieldDeserInfo(caseDefType);
+
     return {
+      [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       [caseDefType.name]: this.readMemberFieldValue(
         fieldDeserInfo,
         reader,

--- a/packages/omgidl-serialization/src/constants.ts
+++ b/packages/omgidl-serialization/src/constants.ts
@@ -1,1 +1,2 @@
-export const UNION_DISCRIMINATOR_PROPERTY_KEY = "_d";
+/** Per: https://www.omg.org/spec/DDS-JSON/1.0/Beta1/PDF */
+export const UNION_DISCRIMINATOR_PROPERTY_KEY = "$discriminator";

--- a/packages/omgidl-serialization/src/constants.ts
+++ b/packages/omgidl-serialization/src/constants.ts
@@ -1,0 +1,1 @@
+export const UNION_DISCRIMINATOR_PROPERTY_KEY = "_d";

--- a/packages/omgidl-serialization/src/index.ts
+++ b/packages/omgidl-serialization/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./MessageReader";
 export * from "./MessageWriter";
+export * from "./constants";


### PR DESCRIPTION
Deserialized union fields now hold their discriminator value under the property key "$discriminator", as per [DDS JSON spec](https://www.omg.org/spec/DDS-JSON/1.0/Beta1/PDF).