### PR TITLE
defaults for non-optional mutable members

### DIFF
--- a/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
@@ -341,6 +341,29 @@ describe("DeserializationInfoCache", () => {
       b: 0,
     });
   });
+  it("creates correct default for a struct field with optional and non-optional members", () => {
+    const unionDefinition: IDLMessageDefinition = {
+      name: "test::Message",
+      aggregatedKind: "struct",
+      definitions: [
+        { name: "a", type: "uint32", isComplex: false },
+        {
+          name: "b",
+          type: "uint32",
+          isComplex: false,
+          annotations: {
+            optional: { type: "no-params", name: "optional" },
+          },
+        },
+      ],
+    };
+    const deserializationInfoCache = new DeserializationInfoCache([unionDefinition]);
+    const fieldDeserInfo = makeFieldDeserFromComplexDef(unionDefinition, deserializationInfoCache);
+    expect(deserializationInfoCache.getFieldDefault(fieldDeserInfo)).toEqual({
+      a: 0,
+      b: undefined,
+    });
+  });
   it("throws if required type definitions are not found", () => {
     const deserializationInfoCache = new DeserializationInfoCache([TIME_DEFINITION]);
     expect(() =>

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -311,7 +311,9 @@ export class DeserializationInfoCache {
       } else if (deserInfo.type === "struct") {
         defaultMessage = {};
         for (const field of deserInfo.fields) {
-          defaultMessage[field.name] = this.getFieldDefault(field);
+          if (!field.isOptional) {
+            defaultMessage[field.name] = this.getFieldDefault(field);
+          }
         }
       }
 

--- a/packages/omgidl-serialization/src/defaultValues.ts
+++ b/packages/omgidl-serialization/src/defaultValues.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_BOOLEAN_VALUE = false;
+export const DEFAULT_STRING_VALUE = "";
+export const DEFAULT_NUMERICAL_VALUE = 0;
+export const DEFAULT_BYTE_VALUE = 0x00;


### PR DESCRIPTION
### Public-Facing Changes
<!-- describe any changes to the public interface or APIs, or write "None" -->
 - non-optional fields for mutable structs and unions now receive default values

### Description

Most of this is done in the DeserializationInfoCache since we generally want to cache default values for complex types. 
Primitive fields receive default values per spec. Default values for fixed size arrays are given
Default unions use a default case if one exists, otherwise they use the case selected by the default value of the switch case type.
Default structs are filled with non-optional members' default values.

Reference: https://www.omg.org/spec/DDS-XTypes/1.3/PDF
7.2.2.4.4.4.7
![image](https://github.com/foxglove/omgidl/assets/10187776/28be56ff-69f5-4fcd-bbce-d504a3099858)

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
FG-6554
