### PR TITLE
Bump omgidl-parser v1.0.4, omgidl-serialization v1.1.1

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### update `omgidl-parser` package minor version (v1.0.3 -> v1.0.4). 

Changes:
 - parser now supports field names with the same name as modules and structs.


### update `omgidl-serialization` package minor version (v1.1.0 -> v1.1.1). 

Changes:
 - message reader now assigns default values to non-optional mutable fields