### PR TITLE
Add provenance attestation when publishing to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     name: all
     runs-on: ubuntu-latest
 
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,20 +36,26 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - run: yarn workspace @foxglove/omgidl-parser pack
       - name: Publish `omgidl-parser` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-parser/v') }}
-        run: yarn workspace @foxglove/omgidl-parser npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish packages/omgidl-parser/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      - run: yarn workspace @foxglove/omgidl-serialization pack
       - name: Publish `omgidl-serialization` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/omgidl-serialization/v') }}
-        run: yarn workspace @foxglove/omgidl-serialization npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish packages/omgidl-serialization/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+      - run: yarn workspace @foxglove/ros2idl-parser pack
       - name: Publish `ros2idl-parser` to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/ros2idl-parser/v') }}
-        run: yarn workspace @foxglove/ros2idl-parser npm publish --access public
+        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
+        run: npm publish packages/ros2idl-parser/package.tgz --provenance --access public
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
           cache: yarn
 


### PR DESCRIPTION
### Changelog
None

### Description

This adds a provenance attestation to the published package so consumers can verify that the package was built on GitHub Actions:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

The package will appear like this on npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">
