### PR TITLE
support `include` as a field name

### DIFF
--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -7,7 +7,6 @@ const keywords = [
   , "module"
   , "enum"
   , "const"
-  , "include"
   , "typedef"
   , "union"
   , "switch"

--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -2674,4 +2674,24 @@ module rosidl_parser {
     };`;
     expect(() => parse(msgDef)).toThrow(/unexpected RCBR token: "}"/i);
   });
+  it("supports 'include' as a field name", () => {
+    const msgDef = `
+    struct SomeStruct {
+      boolean include;
+    };`;
+    const ast = parseIDL(msgDef);
+    expect(ast).toEqual([
+      {
+        name: "SomeStruct",
+        aggregatedKind: "struct",
+        definitions: [
+          {
+            name: "include",
+            isComplex: false,
+            type: "bool",
+          },
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### Changelog
support `include` as a field name

### Docs
None

### Description
We were treating `include` as a keyword in our nearly grammar even though it is not considered a keyword in the OMGIDL spec. This PR fixes this which allows to use `include` as a regular field name.