### PR TITLE
Add support for empty structs

### DIFF
--- a/packages/omgidl-parser/src/idl.ne
+++ b/packages/omgidl-parser/src/idl.ne
@@ -231,7 +231,7 @@ enumFieldName -> multiAnnotations fieldName {% d => {
   return extend([annotations, name]);
 } %}
 
-struct -> "struct" fieldName "{" (member):+ "}" {% d => {
+struct -> "struct" fieldName "{" (member):* "}" {% d => {
   const name = d[1].name;
   const definitions = d[3].flat(2).filter(def => def !== null);
   return {

--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -2619,6 +2619,20 @@ module rosidl_parser {
       },
     ]);
   });
+  it("can parse empty struct", () => {
+    const msgDef = `
+      struct a {
+      };
+    `;
+    const ast = parseIDL(msgDef);
+    expect(ast).toEqual([
+      {
+        name: "a",
+        aggregatedKind: "struct",
+        definitions: [],
+      },
+    ]);
+  });
   // **************** Not supported in our implementation yet
   it("cannot compose variable size arrays (no serialization support)", () => {
     const msgDef = `

--- a/packages/omgidl-parser/src/parseIDLToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIDLToAST.test.ts
@@ -1798,6 +1798,20 @@ module idl_parser {
       },
     ]);
   });
+  it("can parse empty struct", () => {
+    const msgDef = `
+      struct a {
+      };
+    `;
+    const ast = parseIDLToAST(msgDef);
+    expect(ast).toEqual([
+      {
+        name: "a",
+        declarator: "struct",
+        definitions: [],
+      },
+    ]);
+  });
   /****************  Not supported by IDL (as far as I can tell) */
   it("cannot parse constants that reference other constants", () => {
     const msgDef = `
@@ -1818,20 +1832,6 @@ module idl_parser {
       };
     `;
     expect(() => parseIDLToAST(msgDef)).toThrow(/unexpected , token/i);
-  });
-  it("can parse empty struct", () => {
-    const msgDef = `
-      struct a {
-      };
-    `;
-    const ast = parseIDLToAST(msgDef);
-    expect(ast).toEqual([
-      {
-        name: "a",
-        declarator: "struct",
-        definitions: [],
-      },
-    ]);
   });
   /****************  Syntax Errors */
   it("missing bracket at the end will result in end of input error", () => {

--- a/packages/omgidl-parser/src/parseIDLToAST.test.ts
+++ b/packages/omgidl-parser/src/parseIDLToAST.test.ts
@@ -1819,12 +1819,19 @@ module idl_parser {
     `;
     expect(() => parseIDLToAST(msgDef)).toThrow(/unexpected , token/i);
   });
-  it("cannot parse empty struct", () => {
+  it("can parse empty struct", () => {
     const msgDef = `
       struct a {
       };
     `;
-    expect(() => parseIDLToAST(msgDef)).toThrow(/unexpected RCBR token/i);
+    const ast = parseIDLToAST(msgDef);
+    expect(ast).toEqual([
+      {
+        name: "a",
+        declarator: "struct",
+        definitions: [],
+      },
+    ]);
   });
   /****************  Syntax Errors */
   it("missing bracket at the end will result in end of input error", () => {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1326,6 +1326,20 @@ module builtin_interfaces {
     `;
     const data = {};
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+
+    const rootDef = "Message";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(writer.data);
+    expect(msgout).toEqual(data);
+  });
+  it("Reads mutable struct with no members", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+      };
+    `;
+    const data = {};
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
     writer.sentinelHeader(); // end of struct
 
     const rootDef = "Message";

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1319,4 +1319,18 @@ module builtin_interfaces {
 
     expect(msgout).toEqual(data);
   });
+  it("Reads struct with no members", () => {
+    const msgDef = `
+      struct Message {
+      };
+    `;
+    const data = {};
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(writer.data);
+    expect(msgout).toEqual(data);
+  });
 });


### PR DESCRIPTION
### Changelog
Add support for empty structs

### Docs
None

### Description
As per the [IDL spec](https://www.omg.org/spec/IDL/4.1/PDF), structs are allowed to have no members:

>```
>::+ "struct" <identifier> ":" <scoped_name> "{" <member>* "}"
>| "struct" <identifier> "{" "}"
>```

Our parsing grammar however required a struct to have at least one member. This PR adapts the grammar to allow structs without members.
