### PR TITLE
Bump omgidl-parser v1.0.5

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### update `omgidl-parser` package minor version (v1.0.4 -> v1.0.5). 

Changes:
 - suppot `include` as field name (#166)
 - support empty structs (#167)
