### PR TITLE
Allow unions to be read when there is no matching case or default for the specified discriminator value

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -753,7 +753,7 @@ module builtin_interfaces {
     });
   });
 
-  it("Reads mutable union with default case with id where discriminator case does not exist a", () => {
+  it("Reads mutable union with default case with id where discriminator case does not exist", () => {
     const msgDef = `
         @mutable
         union ColorOrGray switch (uint8) {
@@ -794,7 +794,7 @@ module builtin_interfaces {
       },
     });
   });
-  it("Reads mutable union field with id where discriminator case does not exist", () => {
+  it("Reads mutable union field with with id where discriminator case does not exist and there is no default", () => {
     const msgDef = `
         @mutable
         union ColorOrGray switch (uint8) {


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
- Allow unions to be read when there is no matching case or default for the specified discriminator value

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

See Section 7.4.1.4.4.4.2 of https://www.omg.org/spec/IDL/4.2/PDF:
> It is not required that all possible values of the union discriminator be listed in the <switch_body>. The value of a
union is the value of the discriminator together with one of the following:
> 1. If the discriminator value was explicitly listed in a case statement, the value of the element associated with
> that case statement.
> 2. If a default case label was specified, the value of the element associated with the default case label.
> 3. No additional value.

Previously we were erroring if there was not a case corresponding with the given discriminator value. Now we will return the default if it exists, or an object containing only the discriminator value if there is no default. 

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

