### PR TITLE
Fix edge cases of optional parameters

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -91,6 +91,7 @@ export class MessageReader<T = unknown> {
         reader,
         {
           readMemberHeader,
+          parentName: deserInfo.definition.name ?? "<unnamed-struct>",
         },
         options,
       );
@@ -145,7 +146,7 @@ export class MessageReader<T = unknown> {
         reader,
         {
           readMemberHeader,
-          parentName: deserInfo.definition.name,
+          parentName: deserInfo.definition.name ?? "<unnamed-union>",
         },
         options,
       ),
@@ -162,7 +163,7 @@ export class MessageReader<T = unknown> {
   private readMemberFieldValue(
     field: FieldDeserializationInfo,
     reader: CdrReader,
-    emHeaderOptions: { readMemberHeader: boolean; parentName?: string },
+    emHeaderOptions: { readMemberHeader: boolean; parentName: string },
     childOptions: HeaderOptions,
   ): unknown {
     let emHeaderSizeBytes;
@@ -266,9 +267,7 @@ export class MessageReader<T = unknown> {
       }
     } catch (err: unknown) {
       if (err instanceof Error) {
-        err.message = `${err.message} in field ${field.name} of ${
-          emHeaderOptions.parentName ?? ""
-        } at location ${reader.offset}.`;
+        err.message = `${err.message} in field ${field.name} of ${emHeaderOptions.parentName} at location ${reader.offset}.`;
       }
       throw err;
     }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -166,86 +166,111 @@ export class MessageReader<T = unknown> {
     childOptions: HeaderOptions,
   ): unknown {
     let emHeaderSizeBytes;
-    if (emHeaderOptions.readMemberHeader) {
-      /** If the unusedEmHeader is a sentinel header, then all remaining fields in the struct are absent. */
-      if (this.#unusedEmHeader?.readSentinelHeader === true) {
-        return undefined;
-      }
-
-      const emHeader = this.#unusedEmHeader ?? reader.emHeader();
-
-      const definitionId = field.definitionId;
-
-      if (definitionId != undefined && emHeader.id !== definitionId) {
-        // ID mismatch, save emHeader for next field. Could also be a sentinel header
-        this.#unusedEmHeader = emHeader;
-        if (field.isOptional) {
+    try {
+      // if a field is marked as optional it gets an emHeader regardless of emHeaderOptions
+      // that would be set by the struct's mutability.
+      if (emHeaderOptions.readMemberHeader || field.isOptional) {
+        /** If the unusedEmHeader is a sentinel header, then all remaining fields in the struct are absent. */
+        if (this.#unusedEmHeader?.readSentinelHeader === true) {
           return undefined;
+        }
+
+        let emHeader;
+        try {
+          emHeader = this.#unusedEmHeader ?? reader.emHeader();
+        } catch (err: unknown) {
+          if (err instanceof RangeError && field.isOptional) {
+            // If we get a RangeError, it means we've reached the end of the buffer
+            // This is expected if the field is optional
+            return undefined;
+          }
+          throw err;
+        }
+
+        const definitionId = field.definitionId;
+
+        if (definitionId != undefined && emHeader.id !== definitionId) {
+          // ID mismatch, save emHeader for next field. Could also be a sentinel header
+          this.#unusedEmHeader = emHeader;
+          if (field.isOptional) {
+            return undefined;
+          } else {
+            return this.deserializationInfoCache.getFieldDefault(field);
+          }
+        }
+
+        // emHeader is now being used and should be cleared
+        this.#unusedEmHeader = undefined;
+        const { objectSize: objectSizeBytes, lengthCode } = emHeader;
+
+        if (field.isOptional && objectSizeBytes === 0) {
+          return undefined;
+        }
+
+        emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSizeBytes : undefined;
+      }
+
+      if (field.typeDeserInfo.type === "struct" || field.typeDeserInfo.type === "union") {
+        if (field.isArray === true) {
+          // For dynamic length arrays we need to read a uint32 prefix
+          const arrayLengths = field.arrayLengths ?? [reader.sequenceLength()];
+          return this.readComplexNestedArray(
+            reader,
+            childOptions,
+            field.typeDeserInfo,
+            arrayLengths,
+            0,
+          );
         } else {
-          return this.deserializationInfoCache.getFieldDefault(field);
+          return this.readAggregatedType(
+            field.typeDeserInfo,
+            reader,
+            childOptions,
+            emHeaderSizeBytes,
+          );
+        }
+      } else {
+        const headerSpecifiedLength =
+          emHeaderSizeBytes != undefined
+            ? Math.floor(emHeaderSizeBytes / field.typeDeserInfo.typeLength)
+            : undefined;
+
+        if (field.typeDeserInfo.type === "array-primitive") {
+          const deser = field.typeDeserInfo.deserialize;
+          const arrayLengths =
+            field.arrayLengths ??
+            // the byteLength written in the header doesn't help us determine count of strings in the array
+            // This will be the next field in the message
+            (field.type === "string"
+              ? [reader.sequenceLength()]
+              : [headerSpecifiedLength ?? reader.sequenceLength()]);
+
+          if (arrayLengths.length > 1) {
+            const typedArrayDeserializer = () => {
+              return deser(reader, arrayLengths[arrayLengths.length - 1]!);
+            };
+
+            // last arrayLengths length is handled in deserializer. It returns an array
+            return makeNestedArray(typedArrayDeserializer, arrayLengths.slice(0, -1), 0);
+          } else {
+            return deser(reader, arrayLengths[0]!);
+          }
+        } else if (field.typeDeserInfo.type === "primitive") {
+          return field.typeDeserInfo.deserialize(
+            reader,
+            headerSpecifiedLength, // fieldLength only used for `string` type primitives
+          );
+        } else {
+          throw new Error(`Unhandled deserialization info type`);
         }
       }
-
-      // emHeader is now being used and should be cleared
-      this.#unusedEmHeader = undefined;
-      const { objectSize: objectSizeBytes, lengthCode } = emHeader;
-
-      emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSizeBytes : undefined;
-    }
-
-    if (field.typeDeserInfo.type === "struct" || field.typeDeserInfo.type === "union") {
-      if (field.isArray === true) {
-        // For dynamic length arrays we need to read a uint32 prefix
-        const arrayLengths = field.arrayLengths ?? [reader.sequenceLength()];
-        return this.readComplexNestedArray(
-          reader,
-          childOptions,
-          field.typeDeserInfo,
-          arrayLengths,
-          0,
-        );
-      } else {
-        return this.readAggregatedType(
-          field.typeDeserInfo,
-          reader,
-          childOptions,
-          emHeaderSizeBytes,
-        );
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        err.message = `${err.message} in field ${field.name} of ${
+          emHeaderOptions.parentName ?? ""
+        } at location ${reader.offset}.`;
       }
-    } else {
-      const headerSpecifiedLength =
-        emHeaderSizeBytes != undefined
-          ? Math.floor(emHeaderSizeBytes / field.typeDeserInfo.typeLength)
-          : undefined;
-
-      if (field.typeDeserInfo.type === "array-primitive") {
-        const deser = field.typeDeserInfo.deserialize;
-        const arrayLengths =
-          field.arrayLengths ??
-          // the byteLength written in the header doesn't help us determine count of strings in the array
-          // This will be the next field in the message
-          (field.type === "string"
-            ? [reader.sequenceLength()]
-            : [headerSpecifiedLength ?? reader.sequenceLength()]);
-
-        if (arrayLengths.length > 1) {
-          const typedArrayDeserializer = () => {
-            return deser(reader, arrayLengths[arrayLengths.length - 1]!);
-          };
-
-          // last arrayLengths length is handled in deserializer. It returns an array
-          return makeNestedArray(typedArrayDeserializer, arrayLengths.slice(0, -1), 0);
-        } else {
-          return deser(reader, arrayLengths[0]!);
-        }
-      } else if (field.typeDeserInfo.type === "primitive") {
-        return field.typeDeserInfo.deserialize(
-          reader,
-          headerSpecifiedLength, // fieldLength only used for `string` type primitives
-        );
-      } else {
-        throw new Error(`Unhandled deserialization info type`);
-      }
+      throw err;
     }
   }
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

 - Fix for reading optional fields in final structs, we now expect their emHeaders
 - Fix for reading absent optional fields at the end of a message that would cause a RangeError

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description


Fixes two issues in our implementation of optional fields. 

The first issue (FG-8644) was us not expecting optional parameters of final structs to have emHeaders in XCDR1. 
This is specified in the spec here: 
<img width="595" alt="image" src="https://github.com/user-attachments/assets/3213fa6f-9c0e-4019-afe1-3e0c7f6fe9d4">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/76b09dd7-1637-4515-99e9-b0f1ab675d57">

This was fixed by adding `&& field.isOptional`.

The second issue (FG-8627) fixed occurred in PL_CDR2 when trying to read the absent, optional, final field of a message, which was causing a RangeError because emHeaders are not present for absent optional fields in PL_CDR2 since they are able to check id's of the emHeaders. This was fixed by catching the `RangeError` and returning `undefined` as we do when the emHeader is not the id we expect which is the other case when optional field is not present.

I also wrapped the `readMemberFieldValue` in a `try/catch` to be able to give better error messages at which field failed and where in the serialized message it encountered the error. 




