### PR TITLE
Support `DELIMITED_CDR2`

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1538,8 +1538,8 @@ module builtin_interfaces {
     const data = {
       inners: [],
     };
-    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_CDR2_LE });
-    writer.sentinelHeader(); // end of struct
+    // new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
+    // would write this
     const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
 
     const rootDef = "Outer";
@@ -1557,8 +1557,8 @@ module builtin_interfaces {
     const data = {
       inners: new Uint8Array([]),
     };
-    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_CDR2_LE });
-    writer.sentinelHeader(); // end of struct
+    // new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
+    // would write this
     const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
 
     const rootDef = "Outer";

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1524,4 +1524,46 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
     expect(msgout).toEqual(data);
   });
+  it("Reads appendable struct with complex inner sequence", () => {
+    const msgDef = `
+      @appendable
+      struct Inner {
+        uint32 a;
+      };
+      @appendable
+      struct Outer {
+        sequence<Inner> inners;
+      };
+    `;
+    const data = {
+      inners: [],
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_CDR2_LE });
+    writer.sentinelHeader(); // end of struct
+    const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+
+    const rootDef = "Outer";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(buffer);
+    expect(msgout).toEqual(data);
+  });
+  it("Reads appendable struct with primitive inner sequence", () => {
+    const msgDef = `
+      @appendable
+      struct Outer {
+        sequence<uint8> inners;
+      };
+    `;
+    const data = {
+      inners: new Uint8Array([]),
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_CDR2_LE });
+    writer.sentinelHeader(); // end of struct
+    const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+
+    const rootDef = "Outer";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(buffer);
+    expect(msgout).toEqual(data);
+  });
 });

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1538,9 +1538,15 @@ module builtin_interfaces {
     const data = {
       inners: [],
     };
-    // new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
-    // would write this
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
+    writer.dHeader(8); // for the object
+    writer.dHeader(4); // for the inner sequence field
+    writer.sequenceLength(0);
+
+    // buffer provided from issue https://github.com/foxglove/omgidl/issues/227
+    // written by cyclonedds
     const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+    expect(writer.data).toEqual(buffer);
 
     const rootDef = "Outer";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
@@ -1557,9 +1563,15 @@ module builtin_interfaces {
     const data = {
       inners: new Uint8Array([]),
     };
-    // new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
-    // would write this
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
+    writer.dHeader(8); // for the object
+    writer.dHeader(4); // for the inner sequence field
+    writer.sequenceLength(0);
+
+    // buffer provided from issue https://github.com/foxglove/omgidl/issues/227
+    // written by cyclonedds
     const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+    expect(writer.data).toEqual(buffer);
 
     const rootDef = "Outer";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -171,10 +171,12 @@ export class MessageReader<T = unknown> {
     childOptions: HeaderOptions,
   ): unknown {
     let emHeaderSizeBytes;
+
+    // if a field is marked as optional it gets an emHeader regardless of emHeaderOptions
+    // that would be set by the struct's mutability.
     const readEmHeader = headerOptions.readMemberHeader || field.isOptional;
+
     try {
-      // if a field is marked as optional it gets an emHeader regardless of emHeaderOptions
-      // that would be set by the struct's mutability.
       if (readEmHeader) {
         /** If the unusedEmHeader is a sentinel header, then all remaining fields in the struct are absent. */
         if (this.#unusedEmHeader?.readSentinelHeader === true) {


### PR DESCRIPTION
We weren't writing `DHEADERS` for sequences and arrays that otherwise lack emheaders.
In the [doc](https://www.omg.org/spec/DDS-XTypes/1.3/PDF) they are specified as such:
<img width="520" alt="image" src="https://github.com/user-attachments/assets/5da4fbf7-c759-406f-bb88-bc71346d639e">
<img width="505" alt="image" src="https://github.com/user-attachments/assets/da2ea6dc-90c9-4466-9e15-3f257340998f">

These DHEADERs are superseded by EMHEADERs if they're caught beforehand. (I don't have a place in the doc to point at for this but it's been true for historical data we've received. 


TODO:
- [x] test in app against private sample data to make sure no regressions have occurred. 


Linked issues:
FG-8929
https://github.com/foxglove/omgidl/issues/227