### PR TITLE
Disable labels for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    labels: [] # Disable default labels
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    labels: [] # Disable default labels


### PR DESCRIPTION
My hot take is that these labels have never once helped a single person.