### PR TITLE
omgidl-parser 1.1.0 -> 1.2.0

### DIFF
--- a/packages/omgidl-parser/package.json
+++ b/packages/omgidl-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-parser",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Parse OMG IDL to flattened definitions for serialization",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Changelog

* add support for hexadecimal literals
* add missing reference to CORBA spec in the readme

### Docs

None