### PR TITLE
Make default extensibility comply with spec

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@foxglove/omgidl-parser": "workspace:*",
     "@sounisi5011/jest-binary-data-matchers": "1.2.1",
+    "jest": "29.7.0",
     "typescript": "5.8.3"
   },
   "dependencies": {

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -453,17 +453,19 @@ function getHeaderNeeds(definition: IDLMessageDefinition): {
 } {
   const { annotations } = definition;
 
-  if (!annotations) {
-    return { usesDelimiterHeader: false, usesMemberHeader: false };
+  if (annotations) {
+    if ("final" in annotations) {
+      return { usesDelimiterHeader: false, usesMemberHeader: false };
+    }
+
+    if ("mutable" in annotations) {
+      return { usesDelimiterHeader: true, usesMemberHeader: true };
+    }
   }
 
-  if ("mutable" in annotations) {
-    return { usesDelimiterHeader: true, usesMemberHeader: true };
-  }
-  if ("appendable" in annotations) {
-    return { usesDelimiterHeader: true, usesMemberHeader: false };
-  }
-  return { usesDelimiterHeader: false, usesMemberHeader: false };
+  // Default extensibility is appendable according to section 7.3.1.2.1.8 "Type
+  // Extensibility and Mutability" (page 80) of DDS-XTypes v1.3
+  return { usesDelimiterHeader: true, usesMemberHeader: false };
 }
 
 function getDefinitionId(definition: IDLMessageDefinitionField): number | undefined {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1578,4 +1578,21 @@ module builtin_interfaces {
     const msgout = reader.readMessage(buffer);
     expect(msgout).toEqual(data);
   });
+  it("Reads an XCDR2-encoded struct with unspecified extensibility as if it were appendable", () => {
+    const msgDef = `
+      struct X {
+        uint8 a;
+      };
+    `;
+    const data = {
+      a: 73,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
+    writer.dHeader(1);
+    writer.uint8(data.a);
+    const rootDef = "X";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(writer.data);
+    expect(msgout).toEqual(data);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,7 @@ __metadata:
     "@foxglove/message-definition": "npm:^0.4.0"
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": "npm:1.2.1"
+    jest: "npm:29.7.0"
     typescript: "npm:5.8.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Changelog
* Treat unspecified extensibility as "appendable" and not "final". This improves compliance with the DDS-XTypes v1.3 spec.

### Docs

https://linear.app/foxglove/issue/FG-12261/unannotated-structs-are-treated-as-final-instead-of-appendable

### Description

The DDS-XTypes v1.3 spec stipulates that definitions with unspecified extensibility are to be treated as appendable by default. Both [RTI Connext DDS](https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/extensible_types_guide/extensible_types/Defining_Extensible_Types.htm) and [eProsima Fast DDS](https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/usage/usage.html) follow the spec here. Note that however [CycloneDDS does not](https://github.com/eclipse-cyclonedds/cyclonedds/blob/master/docs/dev/xtypes_relnotes.md#release-09), so this is a breaking change for CycloneDDS users.

Fixes: #312

