### PR TITLE
Fix primitive array deserialization

### DIFF
--- a/packages/omgidl-parser/src/IDLNodes/StructMemberIDLNode.ts
+++ b/packages/omgidl-parser/src/IDLNodes/StructMemberIDLNode.ts
@@ -16,6 +16,8 @@ export class StructMemberIDLNode
       isComplex: this.isComplex,
     };
     if (this.arrayLengths != undefined) {
+      // NOTE: if arrayLengths is undefined that means it is an IDL Sequence
+      // which affects deserialization
       msgDefinitionField.arrayLengths = this.arrayLengths;
     }
     if (this.arrayUpperBound != undefined) {

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -53,8 +53,10 @@ export type PrimitiveDeserializationInfo = {
 
 export type PrimitiveArrayDeserializationInfo = {
   type: "array-primitive";
+  /** The bye length of the type. (ie: 2 bytes for Uint16) */
   typeLength: number;
   deserialize: ArrayDeserializer;
+  isSequence: boolean;
 };
 
 export type StructDeserializationInfo = HeaderOptions & {
@@ -227,6 +229,8 @@ export class DeserializationInfoCache {
             type: "array-primitive",
             deserialize: deserialize as ArrayDeserializer,
             typeLength,
+            // Because arrays require a length, sequences are encoded when there is an absence of arraylengths
+            isSequence: arrayLengths == undefined,
           }
         : {
             type: "primitive",

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -56,7 +56,6 @@ export type PrimitiveArrayDeserializationInfo = {
   /** The bye length of the type. (ie: 2 bytes for Uint16) */
   typeLength: number;
   deserialize: ArrayDeserializer;
-  isSequence: boolean;
 };
 
 export type StructDeserializationInfo = HeaderOptions & {
@@ -229,8 +228,6 @@ export class DeserializationInfoCache {
             type: "array-primitive",
             deserialize: deserialize as ArrayDeserializer,
             typeLength,
-            // Because arrays require a length, sequences are encoded when there is an absence of arraylengths
-            isSequence: arrayLengths == undefined,
           }
         : {
             type: "primitive",

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1564,13 +1564,13 @@ module builtin_interfaces {
       inners: new Uint8Array([]),
     };
     const writer = new CdrWriter({ kind: EncapsulationKind.RTPS_DELIMITED_CDR2_LE });
-    writer.dHeader(8); // for the object
-    writer.dHeader(4); // for the inner sequence field
+    writer.dHeader(4); // for the object
+    // no dheader because primitive sequences don't have a dheader
     writer.sequenceLength(0);
 
     // buffer provided from issue https://github.com/foxglove/omgidl/issues/227
     // written by cyclonedds
-    const buffer = new Uint8Array([0, 9, 0, 0, 8, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+    const buffer = new Uint8Array([0, 9, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
     expect(writer.data).toEqual(buffer);
 
     const rootDef = "Outer";
@@ -1593,6 +1593,24 @@ module builtin_interfaces {
     const rootDef = "X";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
     const msgout = reader.readMessage(writer.data);
+    expect(msgout).toEqual(data);
+  });
+  it("Deserializes XCDR2 struct with primitive sequence", () => {
+    const msgDef = `
+      @appendable
+      struct Outer {
+        sequence<uint8> inners;
+      };
+    `;
+    const data = {
+      inners: new Uint8Array([]),
+    };
+
+    const buffer = new Uint8Array([0, 9, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
+
+    const rootDef = "Outer";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+    const msgout = reader.readMessage(buffer);
     expect(msgout).toEqual(data);
   });
 });

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1568,8 +1568,6 @@ module builtin_interfaces {
     // no dheader because primitive sequences don't have a dheader
     writer.sequenceLength(0);
 
-    // buffer provided from issue https://github.com/foxglove/omgidl/issues/227
-    // written by cyclonedds
     const buffer = new Uint8Array([0, 9, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
     expect(writer.data).toEqual(buffer);
 
@@ -1593,24 +1591,6 @@ module builtin_interfaces {
     const rootDef = "X";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
     const msgout = reader.readMessage(writer.data);
-    expect(msgout).toEqual(data);
-  });
-  it("Deserializes XCDR2 struct with primitive sequence", () => {
-    const msgDef = `
-      @appendable
-      struct Outer {
-        sequence<uint8> inners;
-      };
-    `;
-    const data = {
-      inners: new Uint8Array([]),
-    };
-
-    const buffer = new Uint8Array([0, 9, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]);
-
-    const rootDef = "Outer";
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(buffer);
     expect(msgout).toEqual(data);
   });
 });

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -266,7 +266,7 @@ export class MessageReader<T = unknown> {
           const arrayLengths = field.arrayLengths ?? [
             headerSpecifiedLength ?? reader.sequenceLength(),
           ];
-          if (arrayLengths.length == 1) {
+          if (arrayLengths.length === 1) {
             return deser(reader, arrayLengths[0]!);
           }
           // P_ARRAY types

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -252,9 +252,9 @@ export class MessageReader<T = unknown> {
         if (field.typeDeserInfo.type === "array-primitive") {
           const deser = field.typeDeserInfo.deserialize;
 
-          // SEQUENCE and ARRAY types need dheaders -- this should only ever happen here for strings
-          // P_ARRAY and P_SEQUENCEtypes -- never have a dHeader.
+          // SEQUENCE and ARRAY types need dHeaders -- this should only ever happen here for strings
           // since they are the only type that we call "primitive" here but are not "primitive" to XCDR
+          // P_ARRAY and P_SEQUENCE types -- never have a dHeader (anything that's not a string here)
           // sequences and arrays have dHeaders only when emHeaders were not already written
           if (headerOptions.readDelimiterHeader && !readEmHeader && field.type === "string") {
             // return value is ignored because we don't do partial deserialization
@@ -262,15 +262,14 @@ export class MessageReader<T = unknown> {
             reader.dHeader();
           }
 
-          // Sequence types will never have an arrayLengths
+          // Sequence types will never have an arrayLengths defined
           const arrayLengths = field.arrayLengths ?? [
             headerSpecifiedLength ?? reader.sequenceLength(),
           ];
           if (arrayLengths.length === 1) {
             return deser(reader, arrayLengths[0]!);
           }
-          // P_ARRAY types
-          // Multi-dimensional P_ARRAY types.
+          // Multi-dimensional array types.
           const typedArrayDeserializer = () => {
             return deser(reader, arrayLengths[arrayLengths.length - 1]!);
           };

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -243,6 +243,7 @@ export class MessageReader<T = unknown> {
           );
         }
       } else {
+        // if emheader specified a length it is meant to be used as the sequence length instead of reading the sequence length again
         const headerSpecifiedLength =
           emHeaderSizeBytes != undefined
             ? Math.floor(emHeaderSizeBytes / field.typeDeserInfo.typeLength)
@@ -250,30 +251,33 @@ export class MessageReader<T = unknown> {
 
         if (field.typeDeserInfo.type === "array-primitive") {
           const deser = field.typeDeserInfo.deserialize;
+
+          // SEQUENCE and ARRAY types need dheaders -- this should only ever happen here for strings
+          // P_ARRAY and P_SEQUENCEtypes -- never have a dHeader.
+          // since they are the only type that we call "primitive" here but are not "primitive" to XCDR
           // sequences and arrays have dHeaders only when emHeaders were not already written
-          if (headerOptions.readDelimiterHeader && !readEmHeader) {
+          if (headerOptions.readDelimiterHeader && !readEmHeader && field.type === "string") {
             // return value is ignored because we don't do partial deserialization
             // in that case it would be used to skip the field if it was irrelevant
             reader.dHeader();
           }
-          const arrayLengths =
-            field.arrayLengths ??
-            // the byteLength written in the header doesn't help us determine count of strings in the array
-            // This will be the next field in the message
-            (field.type === "string"
-              ? [reader.sequenceLength()]
-              : [headerSpecifiedLength ?? reader.sequenceLength()]);
 
-          if (arrayLengths.length > 1) {
-            const typedArrayDeserializer = () => {
-              return deser(reader, arrayLengths[arrayLengths.length - 1]!);
-            };
-
-            // last arrayLengths length is handled in deserializer. It returns an array
-            return makeNestedArray(typedArrayDeserializer, arrayLengths.slice(0, -1), 0);
-          } else {
+          // Sequence types will never have an arrayLengths
+          const arrayLengths = field.arrayLengths ?? [
+            headerSpecifiedLength ?? reader.sequenceLength(),
+          ];
+          if (arrayLengths.length == 1) {
             return deser(reader, arrayLengths[0]!);
           }
+          // P_ARRAY types
+          // Multi-dimensional P_ARRAY types.
+          const typedArrayDeserializer = () => {
+            return deser(reader, arrayLengths[arrayLengths.length - 1]!);
+          };
+
+          // last arrayLengths length is handled in deserializer. It returns an array
+          return makeNestedArray(typedArrayDeserializer, arrayLengths.slice(0, -1), 0);
+
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         } else if (field.typeDeserInfo.type === "primitive") {
           return field.typeDeserInfo.deserialize(


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- Fix primitive array deserialization

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Fixes: https://github.com/foxglove/omgidl/issues/314

We were previously assigning all XCDR2 arrays and sequences a dHeader when in reality only "string" arrays and sequences need a dheader in this case. This is because we consider a "string" type a primitive even though it is not considered such by XCDR2. 


<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

