### PR TITLE
Allow enums to be referenced under parent module scope

### DIFF
--- a/packages/omgidl-parser/src/parseIDL.test.ts
+++ b/packages/omgidl-parser/src/parseIDL.test.ts
@@ -862,20 +862,6 @@ module rosidl_parser {
           },
         ],
       },
-      {
-        name: "",
-        aggregatedKind: "module",
-        definitions: [
-          {
-            name: "UNSIGNED_LONG_CONSTANT",
-            type: "uint32",
-            isConstant: true,
-            isComplex: false,
-            value: 42,
-            valueText: "42",
-          },
-        ],
-      },
     ]);
   });
 
@@ -1710,7 +1696,7 @@ module rosidl_parser {
       },
     ]);
   });
-  it("parses enums used as constants", () => {
+  it("parses enums used as constants from both enum and parent module namespaces", () => {
     const msgDef = `
 
     module Test {
@@ -1723,7 +1709,8 @@ module rosidl_parser {
 
     module Scene {
       module DefaultColors {
-        const Test::COLORS red = Test::COLORS::RED;
+        const Test::COLORS red = Test::COLORS::RED; // enum namespace
+        const Test::COLORS red2 = Test::RED; // parent module namespace
       };
       struct Line {
         @default(value=Test::COLORS::GREEN)
@@ -1771,6 +1758,14 @@ module rosidl_parser {
             isComplex: false,
             value: 0,
             valueText: "Test::COLORS::RED",
+          },
+          {
+            isConstant: true,
+            name: "red2",
+            type: "uint32",
+            isComplex: false,
+            value: 0,
+            valueText: "Test::RED",
           },
         ],
       },
@@ -1895,28 +1890,6 @@ module rosidl_parser {
             isArray: true,
             isComplex: false,
             type: "float32",
-          },
-        ],
-      },
-      {
-        name: "",
-        aggregatedKind: "module",
-        definitions: [
-          {
-            name: "rows",
-            isComplex: false,
-            isConstant: true,
-            type: "uint16",
-            value: 4,
-            valueText: "4",
-          },
-          {
-            name: "cols",
-            isComplex: false,
-            isConstant: true,
-            type: "uint16",
-            value: 5,
-            valueText: "5",
           },
         ],
       },
@@ -2052,6 +2025,7 @@ module rosidl_parser {
           { name: "RGB", value: 2, type: "uint32", isConstant: true, isComplex: false },
         ],
       },
+
       {
         name: "Color",
         aggregatedKind: "union",
@@ -2151,7 +2125,7 @@ module rosidl_parser {
       },
     ]);
   });
-  it("can parse union  with multiple predicates declaration", () => {
+  it("can parse union with multiple predicates declaration", () => {
     const msgDef = `
     union MyUnion switch (long) {
         case 1:
@@ -2444,20 +2418,6 @@ module rosidl_parser {
             isComplex: true,
             name: "my_union",
             type: "MyUnion",
-          },
-        ],
-      },
-      {
-        name: "",
-        aggregatedKind: "module",
-        definitions: [
-          {
-            name: "FOUR",
-            isComplex: false,
-            isConstant: true,
-            type: "uint32",
-            value: 4,
-            valueText: "4",
           },
         ],
       },

--- a/packages/ros2idl-parser/src/parse.ros2idl.test.ts
+++ b/packages/ros2idl-parser/src/parse.ros2idl.test.ts
@@ -503,19 +503,6 @@ module rosidl_parser {
           },
         ],
       },
-      {
-        name: "",
-        definitions: [
-          {
-            name: "UNSIGNED_LONG_CONSTANT",
-            type: "uint32",
-            isConstant: true,
-            isComplex: false,
-            value: 42,
-            valueText: "42",
-          },
-        ],
-      },
     ]);
   });
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 - constants outside of enums no longer output from `parseIDL` as Message definitions because they are not needed downstream
- enums can be references from their parent module scope

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Satisfies this requirement from the IDL spec:

<img width="675" height="141" alt="image" src="https://github.com/user-attachments/assets/ec413e97-9b38-4b79-a72c-8c39de36e65e" />

This was accomplished by adding the enum constants again under their parent scope to the IDL Node map. There's no risk of these being added to the output because constants are filtered out. We also don't do any namespace collision checking as is, so that's a bit of a separate issue. 

I also removed us adding module-level constants to the output message definition list. I don't believe that constants other than enums are necessary past parsing the IDL because all constant usage within the IDL definition should be resolved before becoming a message definition. 


<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
FG-12679

