### PR TITLE
Allow for Mutable and Appendable types to really work across schemas. 

### DIFF
--- a/packages/omgidl-serialization/jest.config.js
+++ b/packages/omgidl-serialization/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: "ts-jest",
+  moduleDirectories: ["../../node_modules", "./node_modules"],
+  setupFilesAfterEnv: ["@sounisi5011/jest-binary-data-matchers"],
+  testMatch: ["<rootDir>/src/**/*.test.ts"],
+  transform: {
+    "^.+\\.ts$": "ts-jest",
+  },
+};

--- a/packages/omgidl-serialization/jest.config.json
+++ b/packages/omgidl-serialization/jest.config.json
@@ -1,7 +1,0 @@
-{
-  "setupFilesAfterEnv": ["@sounisi5011/jest-binary-data-matchers"],
-  "testMatch": ["<rootDir>/src/**/*.test.ts"],
-  "transform": {
-    "^.+\\.ts$": "ts-jest"
-  }
-}

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -51,7 +51,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@foxglove/cdr": "3.3.0",
+    "@foxglove/cdr": "3.4.0",
     "@foxglove/message-definition": "^0.4.0"
   }
 }

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -51,7 +51,7 @@
     "typescript": "5.8.3"
   },
   "dependencies": {
-    "@foxglove/cdr": "3.4.0",
+    "@foxglove/cdr": "3.5.0",
     "@foxglove/message-definition": "^0.4.0"
   }
 }

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
@@ -69,7 +69,7 @@ describe("DeserializationInfoCache", () => {
     const timeDeserInfo = deserializationInfoCache.getComplexDeserializationInfo(TIME_DEFINITION);
     expect(timeDeserInfo).toMatchObject({
       type: "struct",
-      fields: [
+      fieldsInOrder: [
         {
           name: "sec",
           type: "int32",
@@ -102,13 +102,13 @@ describe("DeserializationInfoCache", () => {
       deserializationInfoCache.getComplexDeserializationInfo(TRANSFORM_DEFINITION);
     expect(timeDeserInfo).toMatchObject({
       type: "struct",
-      fields: [
+      fieldsInOrder: [
         {
           name: "translation",
           type: "geometry_msgs::msg::Vector3",
           typeDeserInfo: {
             type: "struct",
-            fields: [
+            fieldsInOrder: [
               {
                 name: "x",
                 ...FLOAT64_PRIMITIVE_DESER_INFO,
@@ -129,7 +129,7 @@ describe("DeserializationInfoCache", () => {
           type: "geometry_msgs::msg::Quaternion",
           typeDeserInfo: {
             type: "struct",
-            fields: [
+            fieldsInOrder: [
               {
                 name: "x",
                 ...FLOAT64_PRIMITIVE_DESER_INFO,
@@ -196,7 +196,7 @@ describe("DeserializationInfoCache", () => {
       type: "builtin_interfaces::Time",
       typeDeserInfo: {
         type: "struct",
-        fields: [
+        fieldsInOrder: [
           {
             name: "sec",
             type: "int32",
@@ -234,7 +234,7 @@ describe("DeserializationInfoCache", () => {
       isArray: true,
       typeDeserInfo: {
         type: "struct",
-        fields: [
+        fieldsInOrder: [
           {
             name: "x",
             ...FLOAT64_PRIMITIVE_DESER_INFO,

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -163,10 +163,20 @@ export class DeserializationInfoCache {
       }
       fieldsInOrder.push(this.buildFieldDeserInfo(field));
     }
+
+    /**
+     * By default if autoid is not present, then mutable structs get their ids assigned from according to
+     * `@autoid(SEQUENTIAL)`.
+     * If `@autoid` is present, it defaults to the `HASH` method, which we cannot support. We would only support SEQUENTIAL.
+     * Also we don't have a notion of built-in annotations with enums (ie: `@autoid(SEQUENTIAL)`) so we'll actually fail at parsing this.
+     * So for now we're just going to fail if the annotation is present.
+     */
     // specifies the behavior of implicit ids for mutable members
     const autoidAnnotation = definition.annotations?.["autoid"];
-    if (autoidAnnotation?.type === "const-param" && autoidAnnotation.value !== "SEQUENTIAL") {
-      throw new Error("Non-sequential autoid annotations are not supported.");
+    if (autoidAnnotation != undefined) {
+      throw new Error(
+        `@autoid annotations are not supported. If you are using @autoid(SEQUENTIAL) then remove the annotation. @autoid(HASH) is not supported.`,
+      );
     }
 
     const fieldIndexById = new Map<number, number>();

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -165,10 +165,8 @@ export class DeserializationInfoCache {
     }
     // specifies the behavior of implicit ids for mutable members
     const autoidAnnotation = definition.annotations?.["autoid"];
-    if (autoidAnnotation?.type === "const-param" && autoidAnnotation.value === "HASH") {
-      throw new Error(
-        "Hash autoid is not supported because OMGIDL docs do not specify a hashing algorithm.",
-      );
+    if (autoidAnnotation?.type === "const-param" && autoidAnnotation.value !== "SEQUENTIAL") {
+      throw new Error("Non-sequential autoid annotations are not supported.");
     }
 
     const fieldsById = new Map<number, FieldDeserializationInfo>();

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1652,64 +1652,6 @@ module builtin_interfaces {
 
     expect(msgout).toEqual(data);
   });
-  it("Reads XCDR1 appendable struct with missing appended member (old schema new message)", () => {
-    const msgDef = `
-      @appendable
-      struct Message {
-        uint8 bittybyte;
-        float floaty;
-        uint32 bytier;
-      };
-    `;
-    const data = {
-      bittybyte: 5,
-      floaty: 0.5,
-      bytier: 9,
-    };
-    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-    writer.uint8(data.bittybyte);
-    writer.float32(data.floaty);
-    writer.uint32(data.bytier);
-    writer.uint32(12);
-    writer.sentinelHeader(); // end of struct
-
-    const rootDef = "Message";
-
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-
-    const msgout = reader.readMessage(writer.data);
-
-    expect(msgout).toEqual(data);
-  });
-  it("Reads XCDR2 appendable struct with missing appended member (old schema new message)", () => {
-    const msgDef = `
-      @appendable
-      struct Message {
-        uint8 bittybyte;
-        float floaty;
-        uint32 bytier;
-      };
-    `;
-    const data = {
-      bittybyte: 5,
-      floaty: 0.5,
-      bytier: 9,
-    };
-    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
-    writer.dHeader(1 + 4 + 4 + 4);
-    writer.uint8(data.bittybyte);
-    writer.float32(data.floaty);
-    writer.uint32(data.bytier);
-    writer.uint32(12);
-
-    const rootDef = "Message";
-
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-
-    const msgout = reader.readMessage(writer.data);
-
-    expect(msgout).toEqual(data);
-  });
   it("Reads XCDR1 mutable struct with out of order member headers", () => {
     const msgDef = `
       @mutable
@@ -1740,6 +1682,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR2 mutable struct with out of order member headers", () => {
     const msgDef = `
@@ -1771,6 +1714,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR1 mutable struct with out of order member headers and a missing member", () => {
     const msgDef = `
@@ -1800,6 +1744,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR2 mutable struct with out of order member headers and a missing member", () => {
     const msgDef = `
@@ -1829,6 +1774,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR1 mutable struct with appended extra member header", () => {
     const msgDef = `
@@ -1862,6 +1808,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR2 mutable struct with appended extra member header", () => {
     const msgDef = `
@@ -1895,6 +1842,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR1 mutable struct with inserted extra member header", () => {
     const msgDef = `
@@ -1929,6 +1877,7 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
   it("Reads XCDR2 mutable struct with inserted extra member header", () => {
     const msgDef = `
@@ -1962,5 +1911,6 @@ module builtin_interfaces {
     const msgout = reader.readMessage(writer.data);
 
     expect(msgout).toEqual(data);
+    expect(reader.lastMessageBufferEndReached()).toBe(true);
   });
 });

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -447,8 +447,8 @@ module builtin_interfaces {
     `;
 
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
-    writer.dHeader(1); // first writes dHeader for struct object - not taken into consideration for objects
-    writer.emHeader(true, 1, 1); // then writes emHeader for struct object
+    writer.dHeader(4); // first writes dHeader for struct object
+    writer.emHeader(true, 0, 1); // then writes emHeader for struct object
     writer.uint8(0x0f); // then writes the octet
 
     const rootDef = "Address";
@@ -480,14 +480,14 @@ module builtin_interfaces {
       age: 30,
     };
 
-    writer.dHeader(1);
-    writer.emHeader(true, 1, 8); // heightMeters emHeader
+    writer.dHeader(4 + 8 + 8 + 4 + 1 + 4 + 1);
+    writer.emHeader(true, 0, 8); // heightMeters emHeader
     writer.float64(data.heightMeters);
-    writer.emHeader(true, 2, 4 + 4 + 1); // address emHeader
+    writer.emHeader(true, 1, 4 + 1, 5); // address emHeader, use LC=5 so that NEXTINT is used as the length of the next member
     // dHeader for inner object not written again because the object size is already specified in the emHeader and the lengthCode of 5 allows it to not be written again
-    writer.emHeader(true, 1, 1, 5); // pointer emHeader
+    writer.emHeader(true, 0, 1); // pointer emHeader
     writer.uint8(data.address.pointer);
-    writer.emHeader(true, 3, 1); // age emHeader
+    writer.emHeader(true, 2, 1); // age emHeader
     writer.uint8(data.age);
 
     const rootDef = "Person";
@@ -510,7 +510,7 @@ module builtin_interfaces {
 
     // PL_CDRv1 does not have dHeaders and uses sentinel headers
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-    writer.emHeader(true, 1, 1); // then writes emHeader for struct object
+    writer.emHeader(true, 0, 1); // then writes emHeader for struct object
     writer.uint8(0x0f); // then writes the octet
     writer.sentinelHeader();
 
@@ -544,14 +544,14 @@ module builtin_interfaces {
       age: 30,
     };
 
-    writer.emHeader(true, 1, 8); // heightMeters emHeader
+    writer.emHeader(true, 0, 8); // heightMeters emHeader
     writer.float64(data.heightMeters);
-    writer.emHeader(true, 2, 4 + 4 + 1); // address emHeader
+    writer.emHeader(true, 1, 4 + 4 + 1); // address emHeader
     // dHeader for inner object not written again because the object size is already specified in the emHeader
-    writer.emHeader(true, 1, 1); // pointer emHeader
+    writer.emHeader(true, 0, 1); // pointer emHeader
     writer.uint8(data.address.pointer);
     writer.sentinelHeader();
-    writer.emHeader(true, 3, 1); // age emHeader
+    writer.emHeader(true, 2, 1); // age emHeader
     writer.uint8(data.age);
     writer.sentinelHeader();
 
@@ -585,18 +585,18 @@ module builtin_interfaces {
       count: 3,
     };
 
-    writer.dHeader(1);
-    writer.emHeader(true, 1, data.name.length + 1, 2); // "name" field emHeader. add 1 for null terminator
+    writer.dHeader(data.name.length + 1 + 4 + 4 + (3 * 8 + 8) + (3 * 8 + 8) + 8);
+    writer.emHeader(true, 0, data.name.length + 1 + 4, 3); // "name" field emHeader. add 1 for null terminator
     writer.string(data.name, true); // need to write length because lengthCode < 5
 
-    writer.emHeader(true, 2, 3 * 8, 7); // xValues emHeader
+    writer.emHeader(true, 1, 3 * 8, 7); // xValues emHeader
     writer.float64Array(data.xValues, false); // do not write length of array again. Already included in emHeader when lengthCode is 7
 
     // size in only emheader means that lengthcode > 4
-    writer.emHeader(true, 3, 3 * 8, 7); // yValues emHeader, lengthCode = 7 means we don't have to write sequenceLength
+    writer.emHeader(true, 2, 3 * 8, 7); // yValues emHeader, lengthCode = 7 means we don't have to write sequenceLength
     writer.float64Array(data.yValues, false); // do not write length of array again. Already included in emHeader
 
-    writer.emHeader(true, 4, 4); // count emHeader
+    writer.emHeader(true, 3, 4); // count emHeader
     writer.uint32(data.count);
 
     const rootDef = "Plot";
@@ -629,16 +629,18 @@ module builtin_interfaces {
       count: 3,
     };
 
-    writer.dHeader(1);
-    writer.emHeader(true, 1, data.name.length + 1, 2); // "name" field emHeader. add 1 for null terminator
+    writer.dHeader(
+      4 + data.name.length + 1 + 4 + (4 + 4 + 4 + 3 * 8) + (4 + 4 + 4 + 3 * 8) + (4 + 4),
+    ); // (4 + 4 + 4 + 3 * 8) for arrays because emHeader is writing NEXTINT
+    writer.emHeader(true, 0, data.name.length + 1 + 4, 3); // "name" field emHeader. add 1 for null terminator
     writer.string(data.name, true); // need to write length because lengthCode < 5
-    writer.emHeader(true, 2, 3 * 8 + 1, 4); // xValues emHeader
+    writer.emHeader(true, 1, 3 * 8 + 4, 4); // xValues emHeader
     writer.float64Array(data.xValues, /*writeLength:*/ true); // write length because lengthCode < 5
 
-    writer.emHeader(true, 3, 3 * 8 + 1, 4); // yValues emHeader
+    writer.emHeader(true, 2, 3 * 8 + 4, 4); // yValues emHeader
     writer.float64Array(data.yValues, /*writeLength:*/ true); // write length because lengthCode < 5
 
-    writer.emHeader(true, 4, 4); // count emHeader
+    writer.emHeader(true, 3, 4); // count emHeader
     writer.uint32(data.count);
 
     const rootDef = "Plot";
@@ -667,7 +669,8 @@ module builtin_interfaces {
       ],
     };
     const writer = new CdrWriter({ size: 1028, kind: EncapsulationKind.PL_CDR2_LE });
-    writer.emHeader(true, 1, data.grid.length * data.grid[0]!.length * 4); // size of grid
+    writer.dHeader(4 + data.grid.length * data.grid[0]!.length * 4);
+    writer.emHeader(true, 0, data.grid.length * data.grid[0]!.length * 4, 7); // size of grid
     for (const row of data.grid) {
       writer.float32Array(row, false); // do not write length for fixed-size arrays
     }
@@ -693,7 +696,7 @@ module builtin_interfaces {
     };
 
     writer.dHeader(1); // dHeader of struct
-    writer.emHeader(true, 1, data.numbers.length + 4, 2); // writes 4 because the sequence length is after it
+    writer.emHeader(true, 0, data.numbers.length + 4, 2); // writes 4 because the sequence length is after it
     writer.sequenceLength(0); // Because its lengthCode < 5
 
     const rootDef = "Array";
@@ -895,7 +898,7 @@ module builtin_interfaces {
     writer.emHeader(true, 10, 26); // writes emHeader for arr field sequence
     writer.sequenceLength(data.arr.length);
     for (const inner of data.arr) {
-      writer.dHeader(8); // write dHeader for Inner struct
+      writer.dHeader(5); // write dHeader for Inner struct
       writer.emHeader(true, 100, 1); // writes emHeader for a field
       writer.uint8(inner.a);
     }
@@ -1033,7 +1036,7 @@ module builtin_interfaces {
     };
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
     writer.emHeader(false, 100, 1, 0);
-    writer.uint32(data.bittybyte);
+    writer.uint8(data.bittybyte);
     writer.emHeader(false, 200, 4, 0);
     writer.uint32(data.bytier);
     writer.sentinelHeader(); // end of struct
@@ -1591,6 +1594,373 @@ module builtin_interfaces {
     const rootDef = "X";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
     const msgout = reader.readMessage(writer.data);
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 appendable struct", () => {
+    const msgDef = `
+      @appendable
+      struct Message {
+        uint8 bittybyte;
+        float floaty;
+        uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.uint8(data.bittybyte);
+    writer.float32(data.floaty);
+    writer.uint32(data.bytier);
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 appendable struct", () => {
+    const msgDef = `
+      @appendable
+      struct Message {
+        uint8 bittybyte;
+        float floaty;
+        uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 + 4 + 1);
+    writer.uint8(data.bittybyte);
+    writer.float32(data.floaty);
+    writer.uint32(data.bytier);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 appendable struct with missing appended member (old schema new message)", () => {
+    const msgDef = `
+      @appendable
+      struct Message {
+        uint8 bittybyte;
+        float floaty;
+        uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.uint8(data.bittybyte);
+    writer.float32(data.floaty);
+    writer.uint32(data.bytier);
+    writer.uint32(12);
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 appendable struct with missing appended member (old schema new message)", () => {
+    const msgDef = `
+      @appendable
+      struct Message {
+        uint8 bittybyte;
+        float floaty;
+        uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(1 + 4 + 4 + 4);
+    writer.uint8(data.bittybyte);
+    writer.float32(data.floaty);
+    writer.uint32(data.bytier);
+    writer.uint32(12);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 mutable struct with out of order member headers", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 mutable struct with out of order member headers", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 + 4 + 4 + 4 + 4 + 1);
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 mutable struct with out of order member headers and a missing member", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 mutable struct with out of order member headers and a missing member", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 + 4 + 4 + 1);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 mutable struct with appended extra member header", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 400, 4); // doesn't exist on schema
+    writer.uint32(12);
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 mutable struct with appended extra member header", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 + 4 + 4 + 4 + 4 + 1 + 4 + 4);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+    writer.emHeader(false, 400, 4); // doesn't exist on schema
+    writer.uint32(12);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR1 mutable struct with inserted extra member header", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 250, 4); // doesn't exist on schema
+    writer.uint32(12);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+
+    writer.sentinelHeader(); // end of struct
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual(data);
+  });
+  it("Reads XCDR2 mutable struct with inserted extra member header", () => {
+    const msgDef = `
+      @mutable
+      struct Message {
+        @id(100) uint8 bittybyte;
+        @id(200) float floaty;
+        @id(300) uint32 bytier;
+      };
+    `;
+    const data = {
+      bittybyte: 5,
+      floaty: 0.5,
+      bytier: 9,
+    };
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 + 4 + 4 + 4 + 4 + 1 + 4 + 4);
+    writer.emHeader(false, 100, 1);
+    writer.uint8(data.bittybyte);
+    writer.emHeader(false, 200, 4);
+    writer.float32(data.floaty);
+    writer.emHeader(false, 250, 4); // doesn't exist on schema
+    writer.uint32(12);
+    writer.emHeader(false, 300, 4);
+    writer.uint32(data.bytier);
+
+    const rootDef = "Message";
+
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
     expect(msgout).toEqual(data);
   });
 });

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -1,4 +1,4 @@
-import { CdrReader } from "@foxglove/cdr";
+import { CdrReader, EncapsulationKind } from "@foxglove/cdr";
 import {
   IDLMessageDefinition,
   IDLMessageDefinitionField,
@@ -39,65 +39,187 @@ export class MessageReader<T = unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
+    // if true means that it is definitely using CDR2 (however doesn't apply to CDR2 Final (non PL_CDR and non DELIMITED_CDR2))
     const usesDelimiterHeader = reader.usesDelimiterHeader;
     const usesMemberHeader = reader.usesMemberHeader;
 
     return this.readAggregatedType(this.rootDeserializationInfo, reader, {
       usesDelimiterHeader,
       usesMemberHeader,
+      isCDR2: readerIsCDR2(reader),
     }) as R;
   }
 
   private readAggregatedType(
     deserInfo: ComplexDeserializationInfo,
     reader: CdrReader,
-    options: HeaderOptions,
+    options: HeaderOptions & { isCDR2: boolean },
     /** The size of the struct if known (like from an emHeader). If it is known we do not read in a dHeader */
     knownTypeSize?: number,
   ): Record<string, unknown> {
     const readDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
-    const readMemberHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
 
+    let typeEndOffset: number | undefined =
+      knownTypeSize != undefined ? reader.offset + knownTypeSize : undefined;
     // Delimiter header is only read/written if the size of the type is not yet known
     // (If it hasn't already been read in from a surrounding emHeader)
     if (knownTypeSize == undefined && readDelimiterHeader) {
-      reader.dHeader();
+      const objectSize = reader.dHeader();
+      typeEndOffset = reader.offset + objectSize;
     }
 
     const msg =
       deserInfo.type === "struct"
-        ? this.readStructType(deserInfo, reader, options)
-        : this.readUnionType(deserInfo, reader, options);
+        ? this.readStructType(deserInfo, reader, options, typeEndOffset)
+        : this.readUnionType(deserInfo, reader, options, typeEndOffset);
 
-    if (readMemberHeader && this.#unusedEmHeader?.readSentinelHeader !== true) {
-      reader.sentinelHeader();
-    }
-    // clear emHeader for aggregated type, since if it was defined, it would've likely been used
-    // as the sentinel header. This prevents the next field from thinking it's already encountered a sentinel header, and returning undefined.
-    this.#unusedEmHeader = undefined;
     return msg;
   }
 
   private readStructType(
     deserInfo: StructDeserializationInfo,
     reader: CdrReader,
-    options: HeaderOptions,
+    options: HeaderOptions & { isCDR2: boolean },
+    /** if this is present it means that the struct is CDR2 */
+    typeEndOffset: number | undefined,
   ): Record<string, unknown> {
-    const readMemberHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
-    const readDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
+    const usesMemberHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
+    const usesDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
 
     const msg: Record<string, unknown> = {};
-    for (const field of deserInfo.fields) {
-      msg[field.name] = this.readMemberFieldValue(
-        field,
-        reader,
-        {
-          readDelimiterHeader,
-          readMemberHeader,
-          parentName: deserInfo.definition.name ?? "<unnamed-struct>",
-        },
-        options,
-      );
+
+    const needsToReadSentinelHeader = !usesDelimiterHeader && usesMemberHeader; // XCDR1 mutable
+    // this keeps track of whether we've read the sentinel header to close the struct for XCDR1
+    let structIsEnded = false;
+    const fieldNamesRead = new Set<string>();
+
+    // There's a few ways we should be reading structs
+    // 1. Struct is mutable. It has a typeEndOffset. Read based off each EMHEADER. Meaning that we need to read the EMHEADER to determine what the field is and then use the emHeader to read the field.
+    // 2. Struct is appendable. It has a typeEndOffset. Read schema definition from top to bottom, there may be unknown or missing fields that we need to account for.
+    // 3. Read solely based off of the schema definition (FINAL or XCDR1). Meaning that we can assume all the fields are in the exact same order and count as the schema definition.
+    if (usesMemberHeader) {
+      // HANDLE MUTABLE STRUCT
+      // XCDR2 uses typeEndOffset to determine the end of the struct
+      // XCDR1 uses a sentinel header to determine the end of the struct
+
+      // loop until struct is ended: XCDR2 uses typeEndOffset, XCDR1 uses a sentinel header
+      for (;;) {
+        if (typeEndOffset != undefined && reader.offset >= typeEndOffset) {
+          // end of struct
+          structIsEnded = true;
+          break;
+        }
+
+        if (!options.isCDR2 && this.maybeConsumeSentinelHeader(reader)) {
+          // end of struct
+          structIsEnded = true;
+          break;
+        }
+
+        const { objectSize, id, readSentinelHeader, lengthCode } = reader.emHeader();
+        // end of struct, this accounts for XCDR1 mutable structs
+        if (readSentinelHeader === true) {
+          structIsEnded = true;
+          break;
+        }
+
+        const emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSize : undefined;
+        const field = deserInfo.fieldsById.get(id);
+        if (field == undefined) {
+          try {
+            reader.seekTo(reader.offset + objectSize);
+          } catch (err) {
+            if (err instanceof Error && err.message.includes("outside the data range")) {
+              // end of message, cannot seek to end of byte array
+              break;
+            }
+          }
+          continue;
+        }
+
+        fieldNamesRead.add(field.name);
+
+        msg[field.name] = this.readMemberFieldValue(
+          field,
+          reader,
+          {
+            usesDelimiterHeader,
+            usesMemberHeader,
+            parentName: deserInfo.definition.name ?? "<unnamed-struct>",
+            emHeaderSizeBytes,
+            isCDR2: options.isCDR2,
+          },
+          options,
+        );
+      } // END OF MUTABLE FIELD LOOP
+    } else {
+      // HANDLE APPENDABLE OR FINAL STRUCT
+      // Appendable structs are treated the same as final structs except that they have a typeEndOffset
+      // from the DHeader for XCDR2 (has typeEndOffset), or a sentinel header for XCDR1.
+
+      for (const field of deserInfo.fieldsInOrder) {
+        if (typeEndOffset != undefined && reader.offset >= typeEndOffset) {
+          // end of struct
+          // if this happens then it likely means that the schema we have has been appended to but the message
+          // was written using a schema with fewer fields.
+          structIsEnded = true;
+          break;
+        }
+        if (!options.isCDR2 && this.maybeConsumeSentinelHeader(reader)) {
+          // end of struct
+          structIsEnded = true;
+          break;
+        }
+
+        if (field.isOptional) {
+          fieldNamesRead.add(field.name);
+          msg[field.name] = this.readOptionalFinalMember(
+            field,
+            reader,
+            options,
+            deserInfo.definition.name,
+          );
+          continue;
+        }
+
+        // handles optional xcdr2 fields (from is_present=true) and all non-optional fields
+        fieldNamesRead.add(field.name);
+        msg[field.name] = this.readMemberFieldValue(
+          field,
+          reader,
+          {
+            usesDelimiterHeader,
+            usesMemberHeader,
+            parentName: deserInfo.definition.name ?? "<unnamed-struct>",
+            isCDR2: options.isCDR2,
+          },
+          options,
+        );
+      } // END OF FIELD FOR LOOP
+
+      // there's a chance that even after reading through all the fields that we still have more bytes to read because the message was written with a schema that has more fields than the one we have.
+      // seek to the end of the struct because we can't read in any more.
+      if (typeEndOffset != undefined && reader.offset < typeEndOffset) {
+        reader.seekTo(typeEndOffset);
+      }
+    } // END OF APPENDABLE OR FINAL STRUCT
+
+    // set unread fields to defaults
+    for (const field of deserInfo.fieldsInOrder) {
+      if (fieldNamesRead.has(field.name)) {
+        continue;
+      }
+
+      if (field.isOptional) {
+        msg[field.name] = undefined;
+      } else {
+        msg[field.name] = this.deserializationInfoCache.getFieldDefault(field);
+      }
+    }
+
+    if (needsToReadSentinelHeader && !structIsEnded) {
+      // if the sentinel header was not read to close the struct then we need to read it now
+      reader.sentinelHeader();
     }
 
     return msg;
@@ -106,13 +228,14 @@ export class MessageReader<T = unknown> {
   private readUnionType(
     deserInfo: UnionDeserializationInfo,
     reader: CdrReader,
-    options: HeaderOptions,
+    options: HeaderOptions & { isCDR2: boolean },
+    typeEndOffset?: number,
   ): Record<string, unknown> {
-    const shouldReadEmHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
-    const shouldReadDHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
+    const usesMemberHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
+    const usesDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
 
-    // looks like unions print an emHeader for the switchType
-    if (shouldReadEmHeader) {
+    // unions print an emHeader for the switchType
+    if (usesMemberHeader) {
       const { objectSize: objectSizeBytes } = reader.emHeader();
       if (objectSizeBytes !== deserInfo.switchTypeLength) {
         throw new Error(
@@ -141,86 +264,155 @@ export class MessageReader<T = unknown> {
       };
     }
 
+    let caseDefValue: unknown = undefined;
+
+    // even if the union is ended we need to set the defaults
+    if (usesMemberHeader) {
+      const needsToReadSentinelHeader = !usesDelimiterHeader && usesMemberHeader; // XCDR1 mutable
+      // MUTABLE UNION
+      let unionIsEnded = false;
+      if (typeEndOffset != undefined && reader.offset >= typeEndOffset) {
+        // XCDR2
+        unionIsEnded = true;
+      } else if (!options.isCDR2 && this.maybeConsumeSentinelHeader(reader)) {
+        // XCDR1
+        unionIsEnded = true;
+      }
+      if (unionIsEnded) {
+        // if the offset is already at the end of the union then the value of the caseDef is undefined or it's default value
+        if (fieldDeserInfo.isOptional) {
+          caseDefValue = undefined;
+        } else {
+          caseDefValue = this.deserializationInfoCache.getFieldDefault(fieldDeserInfo);
+        }
+      } else {
+        const { objectSize, readSentinelHeader, lengthCode } = reader.emHeader();
+        if (readSentinelHeader === true) {
+          throw new Error("Read sentinel header after it was already consumed for union case");
+        }
+
+        const emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSize : undefined;
+        caseDefValue = this.readMemberFieldValue(
+          fieldDeserInfo,
+          reader,
+          {
+            usesDelimiterHeader,
+            usesMemberHeader,
+            parentName: deserInfo.definition.name ?? "<unnamed-union>",
+            emHeaderSizeBytes,
+            isCDR2: options.isCDR2,
+          },
+          options,
+        );
+        if (needsToReadSentinelHeader) {
+          reader.sentinelHeader();
+        }
+      }
+    } else {
+      // APPENDABLE AND FINAL UNION HANDLING
+
+      if (fieldDeserInfo.isOptional) {
+        caseDefValue = this.readOptionalFinalMember(
+          fieldDeserInfo,
+          reader,
+          options,
+          deserInfo.definition.name,
+        );
+      } else {
+        caseDefValue = this.readMemberFieldValue(
+          fieldDeserInfo,
+          reader,
+          {
+            usesDelimiterHeader,
+            usesMemberHeader,
+            parentName: deserInfo.definition.name ?? "<unnamed-union>",
+            isCDR2: options.isCDR2,
+          },
+          options,
+        );
+      }
+    }
+
     return {
       [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
-      [caseDefType.name]: this.readMemberFieldValue(
-        fieldDeserInfo,
-        reader,
-        {
-          readDelimiterHeader: shouldReadDHeader,
-          readMemberHeader: shouldReadEmHeader,
-          parentName: deserInfo.definition.name ?? "<unnamed-union>",
-        },
-        options,
-      ),
+      [caseDefType.name]: caseDefValue,
     };
   }
 
-  /** Holds the return value of the previously unused emHeader.
-   * emHeaders remain unused if their return ID does not match the field ID.
-   * They become used if a field is encountered that uses the unusedEmHeader.id or
-   * if the unusedEmheader is a sentinel header.
-   **/
-  #unusedEmHeader?: ReturnType<CdrReader["emHeader"]>;
+  /**
+   * Reads an optional final member of a struct or union.
+   * Check for sentinel header before using.
+   * @param field - The field to read.
+   * @param reader - The reader to read from.
+   * @param options - The options to use.
+   * @returns The value of the field.
+   */
+  private readOptionalFinalMember(
+    field: FieldDeserializationInfo,
+    reader: CdrReader,
+    options: HeaderOptions & { isCDR2: boolean },
+    parentName?: string,
+  ): unknown {
+    if (options.isCDR2) {
+      // if it's XCDR2 then it uses an is_present flag to determine if the field is present
+      const isPresent = Boolean(reader.int8());
+      if (!isPresent) {
+        return undefined;
+      }
+      return this.readMemberFieldValue(
+        field,
+        reader,
+        {
+          ...options,
+          parentName: parentName ?? "<unnamed-struct>",
+          isCDR2: options.isCDR2,
+        },
+        options,
+      );
+    } else {
+      // XCDR1 treats optional fields as mutable members
+      const { objectSize, lengthCode } = reader.emHeader();
+
+      if (objectSize === 0) {
+        return undefined;
+      }
+      const emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSize : undefined;
+      return this.readMemberFieldValue(
+        field,
+        reader,
+        {
+          ...options,
+          parentName: parentName ?? "<unnamed-struct>",
+          emHeaderSizeBytes,
+          isCDR2: options.isCDR2,
+        },
+        options,
+      );
+    }
+  }
 
   private readMemberFieldValue(
     field: FieldDeserializationInfo,
     reader: CdrReader,
-    headerOptions: { readMemberHeader: boolean; readDelimiterHeader: boolean; parentName: string },
+    headerOptions: {
+      usesMemberHeader: boolean;
+      usesDelimiterHeader: boolean;
+      parentName: string;
+      emHeaderSizeBytes?: number;
+      isCDR2: boolean;
+    },
     childOptions: HeaderOptions,
   ): unknown {
-    let emHeaderSizeBytes;
-
-    // if a field is marked as optional it gets an emHeader regardless of emHeaderOptions
-    // that would be set by the struct's mutability.
-    const readEmHeader = headerOptions.readMemberHeader || field.isOptional;
+    const emHeaderSizeBytes = headerOptions.emHeaderSizeBytes;
 
     try {
-      if (readEmHeader) {
-        /** If the unusedEmHeader is a sentinel header, then all remaining fields in the struct are absent. */
-        if (this.#unusedEmHeader?.readSentinelHeader === true) {
-          return undefined;
-        }
-
-        let emHeader;
-        try {
-          emHeader = this.#unusedEmHeader ?? reader.emHeader();
-        } catch (err: unknown) {
-          if (err instanceof RangeError && field.isOptional) {
-            // If we get a RangeError, it means we've reached the end of the buffer
-            // This is expected if the field is optional
-            return undefined;
-          }
-          throw err;
-        }
-
-        const definitionId = field.definitionId;
-
-        if (definitionId != undefined && emHeader.id !== definitionId) {
-          // ID mismatch, save emHeader for next field. Could also be a sentinel header
-          this.#unusedEmHeader = emHeader;
-          if (field.isOptional) {
-            return undefined;
-          } else {
-            return this.deserializationInfoCache.getFieldDefault(field);
-          }
-        }
-
-        // emHeader is now being used and should be cleared
-        this.#unusedEmHeader = undefined;
-        const { objectSize: objectSizeBytes, lengthCode } = emHeader;
-
-        if (field.isOptional && objectSizeBytes === 0) {
-          return undefined;
-        }
-
-        emHeaderSizeBytes = useEmHeaderAsLength(lengthCode) ? objectSizeBytes : undefined;
-      }
-
       if (field.typeDeserInfo.type === "struct" || field.typeDeserInfo.type === "union") {
         if (field.isArray === true) {
           // sequences and arrays have dHeaders only when emHeaders were not already written
-          if (headerOptions.readDelimiterHeader && !readEmHeader) {
+          if (
+            headerOptions.usesDelimiterHeader &&
+            !((!headerOptions.isCDR2 && field.isOptional) || headerOptions.usesMemberHeader)
+          ) {
             // return value is ignored because we don't do partial deserialization
             // in that case it would be used to skip the field if it was irrelevant
             reader.dHeader();
@@ -229,7 +421,7 @@ export class MessageReader<T = unknown> {
           const arrayLengths = field.arrayLengths ?? [reader.sequenceLength()];
           return this.readComplexNestedArray(
             reader,
-            childOptions,
+            { ...childOptions, isCDR2: headerOptions.isCDR2 },
             field.typeDeserInfo,
             arrayLengths,
             0,
@@ -238,7 +430,7 @@ export class MessageReader<T = unknown> {
           return this.readAggregatedType(
             field.typeDeserInfo,
             reader,
-            childOptions,
+            { ...childOptions, isCDR2: headerOptions.isCDR2 },
             emHeaderSizeBytes,
           );
         }
@@ -256,7 +448,11 @@ export class MessageReader<T = unknown> {
           // since they are the only type that we call "primitive" here but are not "primitive" to XCDR
           // P_ARRAY and P_SEQUENCE types -- never have a dHeader (anything that's not a string here)
           // sequences and arrays have dHeaders only when emHeaders were not already written
-          if (headerOptions.readDelimiterHeader && !readEmHeader && field.type === "string") {
+          if (
+            headerOptions.usesDelimiterHeader &&
+            headerSpecifiedLength == undefined &&
+            field.type === "string"
+          ) {
             // return value is ignored because we don't do partial deserialization
             // in that case it would be used to skip the field if it was irrelevant
             reader.dHeader();
@@ -297,7 +493,7 @@ export class MessageReader<T = unknown> {
 
   private readComplexNestedArray(
     reader: CdrReader,
-    options: HeaderOptions,
+    options: HeaderOptions & { isCDR2: boolean },
     deserInfo: ComplexDeserializationInfo,
     arrayLengths: number[],
     depth: number,
@@ -319,6 +515,32 @@ export class MessageReader<T = unknown> {
 
     return array;
   }
+
+  /**
+   * Checks if the reader is at a sentinel header and consumes it if it is.
+   * Should only use for XCDR1 mutable structs and unions.
+   * @param reader - The reader to check.
+   * @returns true if it consumed the sentinel header, false otherwise.
+   */
+  private maybeConsumeSentinelHeader(reader: CdrReader): boolean {
+    const offsetBefore = reader.offset;
+    try {
+      reader.sentinelHeader();
+      return true;
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("Expected SENTINEL_PI")) {
+        // reset the reader to the original offset
+        reader.offset = offsetBefore;
+        return false;
+      } else if (err instanceof RangeError) {
+        // it's possible that the buffer is out of bounds
+        reader.offset = offsetBefore;
+        return false;
+      } else {
+        throw err;
+      }
+    }
+  }
 }
 
 function getCaseForDiscriminator(
@@ -338,4 +560,27 @@ function getCaseForDiscriminator(
 /** Only length Codes >= 5 should allow for emHeader sizes to be used in place of other integer lengths */
 function useEmHeaderAsLength(lengthCode: number | undefined): boolean {
   return lengthCode != undefined && lengthCode >= 5;
+}
+
+function readerIsCDR2(reader: CdrReader): boolean {
+  switch (reader.kind) {
+    case EncapsulationKind.CDR_BE:
+    case EncapsulationKind.CDR_LE:
+    case EncapsulationKind.PL_CDR_BE:
+    case EncapsulationKind.PL_CDR_LE:
+      return false;
+    case EncapsulationKind.CDR2_BE:
+    case EncapsulationKind.CDR2_LE:
+    case EncapsulationKind.DELIMITED_CDR2_BE:
+    case EncapsulationKind.DELIMITED_CDR2_LE:
+    case EncapsulationKind.PL_CDR2_BE:
+    case EncapsulationKind.PL_CDR2_LE:
+    case EncapsulationKind.RTPS_CDR2_BE:
+    case EncapsulationKind.RTPS_CDR2_LE:
+    case EncapsulationKind.RTPS_DELIMITED_CDR2_BE:
+    case EncapsulationKind.RTPS_DELIMITED_CDR2_LE:
+    case EncapsulationKind.RTPS_PL_CDR2_BE:
+    case EncapsulationKind.RTPS_PL_CDR2_LE:
+      return true;
+  }
 }

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -194,7 +194,7 @@ export class MessageReader<T = unknown> {
       } // END OF FIELD FOR LOOP
       if (typeEndOffset != undefined && reader.offset < typeEndOffset) {
         throw new Error(
-          `Appendable/Final struct ${deserInfo.definition.name ?? ""} was not read completely. This could be because the schema is missing fields that are present on the message.`,
+          `Buffer for Appendable/Final struct ${deserInfo.definition.name ?? ""} was not read completely. This could be because the schema is missing fields that are present on the message.`,
         );
       }
     } // END OF APPENDABLE OR FINAL STRUCT
@@ -247,12 +247,7 @@ export class MessageReader<T = unknown> {
       const needsToReadSentinelHeader = !usesDelimiterHeader && usesMemberHeader; // XCDR1 mutable
       // MUTABLE UNION
       const atEndOfUnion = typeEndOffset != undefined && reader.offset >= typeEndOffset;
-      // used to check
-      let emHeader: ReturnType<CdrReader["emHeader"]> | undefined = undefined;
-      if (!atEndOfUnion) {
-        // only read emHeader if it's not at the end of the union already
-        emHeader = reader.emHeader();
-      }
+      const emHeader = !atEndOfUnion ? reader.emHeader() : undefined;
       if (atEndOfUnion || emHeader?.readSentinelHeader === true) {
         // if the offset is already at the end of the union then the value of the caseDef is undefined or it's default value
         if (fieldDeserInfo.isOptional) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,10 +529,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@foxglove/cdr@npm:3.3.0"
-  checksum: 10/0dbf487a700b0bb2f21d9f7914ceaab4b274290af470cadfe962cf09727ae8bfde87e207167ae61896e02207eaef5ce3b403e81b34cd7e6cde4be241b596198e
+"@foxglove/cdr@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@foxglove/cdr@npm:3.4.0"
+  checksum: 10/09c285c15cb2a60907393d935d2ab95a8b7ad0e018fe9d9550642822e0e2089750447d405794c352ad00813c235abb5024247b04d19c6b028281d7b49767e625
   languageName: node
   linkType: hard
 
@@ -609,7 +609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": "npm:3.3.0"
+    "@foxglove/cdr": "npm:3.4.0"
     "@foxglove/message-definition": "npm:^0.4.0"
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": "npm:1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,10 +529,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@foxglove/cdr@npm:3.4.0"
-  checksum: 10/09c285c15cb2a60907393d935d2ab95a8b7ad0e018fe9d9550642822e0e2089750447d405794c352ad00813c235abb5024247b04d19c6b028281d7b49767e625
+"@foxglove/cdr@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@foxglove/cdr@npm:3.5.0"
+  checksum: 10/769d72b47a89f3ce7e13a8230fe751f2272298d3e9168b3e441b092333bc1736bf3e63940138482e1848a88f0576b74e38d0214a5e8d8bb835c75803e33eaa0a
   languageName: node
   linkType: hard
 
@@ -609,7 +609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/omgidl-serialization@workspace:packages/omgidl-serialization"
   dependencies:
-    "@foxglove/cdr": "npm:3.4.0"
+    "@foxglove/cdr": "npm:3.5.0"
     "@foxglove/message-definition": "npm:^0.4.0"
     "@foxglove/omgidl-parser": "workspace:*"
     "@sounisi5011/jest-binary-data-matchers": "npm:1.2.1"


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

 - Mutable structs now support out of order members
 - Appendable structs support absence of members in schema (old schema new message still allows for reading, same with vice versa)

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Background on XCDR Appendable vs Mutable extensibility types. 

When an aggregated type (`struct` or `union` ) is `mutable` it means that the struct may be changed across versions by adding/removing members or moving the members around within the schema. Given that these rules are followed and the type was always mutable, this should mean that new schemas are able to read old messages and vice versa without failing (not all data will be available though). `id`'s should not be changed across mutable types however. 

Appendable aggregated types are only expected to be added to over time. Meaning that the fields are always in the same order with greater / fewer fields across time. 

The final extensibility type is `Final` which should not change at all over time. 

The encoding of parts of messages with these extensibility types can change depending on whether it is XCDR2 or not. 

References to all aggregated types encoding pattern is below:

## Changes to how we handle mutable structs

<img width="605" height="208" alt="image" src="https://github.com/user-attachments/assets/2506b8e4-f2d6-419e-a67a-a06dbd4f1c46" />

> <em>Mutable Struct XCDR1</em>

<img width="661" height="375" alt="image" src="https://github.com/user-attachments/assets/2af0bdd2-1cf9-411b-ab79-83865965b6cc" />

> <em>Mutable Struct XCDR2</em>

Previously we were scanning through the members of each struct  and expecting them to match the ids in the emHeaders as we found them, and if the emHeaders weren't present we would assume that field was missing and save that last read, unused emHeader for the next time we were meant to read it. This approach doesn't work for out of order struct members because we were expecting the emHeader order to match the struct field order or otherwise be absent.

A few major changes were made to allow for this.

The first major change is that we don't loop over the struct by the order of fields. We now read the emHeader from the message to determine what field we should be expecting, and use the `id` in the emHeader to find the field in the message. To facilitate this I added to fields to the `deserializationInfo` for structs: `fieldsInOrder` and `fieldsById`.

Initially `fieldsById` was only reading from explicitly defined `ids` for each field, when in reality, if the field doesn't have the `id` annotation it should receive an implied `id` based on its order in the message with some exceptions around explicitly defined ids. I added the setting of these implied ids after the setting of the explicit ids in the `fieldsById` map and did it according to spec: sequentially starting at 0, skipping preset explicit `ids`. 

<img width="652" height="914" alt="image" src="https://github.com/user-attachments/assets/d06dedbf-03cb-4288-9122-8ceca8b73af9" />

> _reference for implied ids for mutable structs_


Now that we can read members out of order we need to know when to stop reading emHeaders so that we don't read outside of the struct. To do this we now take into consideration the `Dheader` present on all XCDR2 Mutable structs, and the SENTINEL_PID which signifies the end of all XCDR1 mutable structs. The DHeader denotes the size of the struct, so we know when we've reached that offset from the start of the struct that the struct is over. Then for the sentinelHeader, we do have the ability to read that alongside the emheader, but I chose to have it check to see if the next reading is a sentinel header and reset the reader back to the original offset if it doesn't encounter it. These two cases give us our exit case from reading the mutable struct.

After reading what we can of the mutable struct from the message, we now have to fill in any missing optional or undefined fields we were expecting. Now we track what members were written to the message, so that we can iterate through the rest of the fields that weren't written to the message and ensure that they are assigned to their proper default values. 

## Changes to Appendable and Final Structs


<img width="638" height="349" alt="image" src="https://github.com/user-attachments/assets/2f0ff3c6-5050-405f-a1d4-f850f1a034ef" />

> <em>Appendable modifies Final Structs and Unions in this way</em>

<img width="665" height="199" alt="image" src="https://github.com/user-attachments/assets/53127e66-1f50-4b5d-a3b8-aebe7816eb6e" />

> <em>Final Struct XCDR 1&2</em>

Two main issues with how we previously handled final/appendable structs:
 1. We didn't stop reading when we reached the Dheader (in the case of a new schema reading an old messages with appendable extensibility type)
 2. We weren't handling final optional members properly.


<img width="596" height="504" alt="image" src="https://github.com/user-attachments/assets/bfe97b77-a598-473b-a5ca-a38376fb1188" />

> <em>While they have the same outer structure for v1 and v2, the encoding of the optional members differ between XCDR1 & XCDR2:</em>

To fix this we are properly checking the is_present flag for XCDR2 structs instead of just checking EMHEADER which should only be used for XCDR1 OPT_FMEMBERS.

Other minor issues:
 -  we weren't setting defaults for missing fields in appendable type structs
   - we now detect end of message and fill in any missing fields from the schema
 - we weren't anticipating for messages that could contain more fields than what the schema had
    - in this case we would have run out of fields in the struct but there is still data left in the struct, so we skip to the end fo the struct using the dheader. (Should also probably support this for XCDR1 🤔 )

## Changes to handling Final/Appendable Unions

<img width="660" height="238" alt="image" src="https://github.com/user-attachments/assets/2b1a2657-879d-42e5-8a58-41079cc5bc66" />

> _ Final/Appendable union serialization_

I think the only thing that's really changed here is the using the is_present flag on OPT_FMEMBERS. 


## Overall changes:
 - Can properly detect that structs and unions have ended by using their Dheaders and sentinel flags
 - more controlled usage of sentinel flags
 - Allow for the reading of mutable structs out of order
 - proper assignment of implied `id`s for members of mutable structs
 - support backward compatibility of appendable structs
 - support proper encoding of OPT_FMEMBERS in XCDR2 using is_present flag. 

Test changes:
 - Some tests used dummy dheaders -- these have been updated to use actual values that can be used so that it doesn't terminate the struct early/late

Off topic changes:
 - fixed jest vscode integration
 - consistent naming of `usesDelimiterHeaders` from `readDelimiterHeaders` (same for EmHeaders)

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
Fixes: https://linear.app/foxglove/issue/FG-12378/appending-fields-to-appendablemutable-structs-breaks-xcdr2-decoding
Fixes: #313
