### PR TITLE
Fix sequential field id assignment

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -1929,7 +1929,7 @@ module builtin_interfaces {
     };
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
     writer.dHeader(4 + 4 + 4 + 4 + 4 + 1);
-    writer.emHeader(false, 0, 4);
+    writer.emHeader(false, 101, 4);
     writer.float32(data.floaty);
     writer.emHeader(false, 300, 4);
     writer.uint32(data.bytier);


### PR DESCRIPTION
### Changelog
Fixed an issue with struct members being read out of order when explicit `@id` annotations were used on only some members.

### Docs

None

### Description

Follow-up from https://github.com/foxglove/omgidl/pull/321

I believe we misunderstood how sequential field `id`s worked. The prior PR said:

> sequentially starting at 0, skipping preset explicit ids.

The correct interpretation is specified at 7.3.1.2.1.1:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7321464c-2b28-49bf-8356-77d95e4bb3de" />

that is: a field's id, if not specified, is equal to the previous field's id + 1.

We do not currently support reading structs that inherit from another struct, so there's no need to start from the id of the last member of the base type — we just start at 0.