### PR TITLE
build: require tar >=7.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.8"
+    "tar": ">=7.5.10"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,7 +6591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=7.5.8":
+"tar@npm:>=7.5.10":
   version: 7.5.11
   resolution: "tar@npm:7.5.11"
   dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump the root Yarn resolution for `tar` from `>=7.5.8` to `>=7.5.10`
- refresh `yarn.lock` so the selector matches the new minimum while continuing to resolve to `tar@7.5.11`

## Testing
- `yarn install --immutable --mode=skip-build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f882da7-492c-4a2f-a5c3-35c8c8c83a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f882da7-492c-4a2f-a5c3-35c8c8c83a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

