### PR TITLE
fix: resolve serialize-javascript RCE vulnerability (GHSA-5c6j-r48x-rmvq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.10"
+    "tar": ">=7.5.10",
+    "serialize-javascript": ">=7.0.3"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5876,15 +5876,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10/4efd1ad3d88db77c2d16588dc54c2b52fd2461e70fe5724611f38d283857094fe09040fa2c9776366803c3152cf133171b452ef717592b65631ce5dc3a2bdafc
-  languageName: node
-  linkType: hard
-
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -6114,7 +6105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -6190,12 +6181,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
+"serialize-javascript@npm:>=7.0.3":
+  version: 7.0.4
+  resolution: "serialize-javascript@npm:7.0.4"
+  checksum: 10/f96d59d6053739785822750e6ffbe06ec5a2651b836b3e6c76742c613e1b2fcb846b5df92294857ecfe69730fe36a1968c0eb8f258b02fd9173a1d5e73f0a32f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves Dependabot alert #54 - High severity RCE vulnerability in `serialize-javascript`.

## Problem

The `serialize-javascript` package (versions ≤7.0.2) contains a high-severity code injection vulnerability ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)) that can lead to remote code execution. The vulnerability exists because `RegExp.flags` and `Date.prototype.toISOString()` are interpolated directly into generated output without proper escaping.

**Dependency chain in this repo:**
```
webpack (5.103.0)
  └── terser-webpack-plugin (^5.3.11)
        └── serialize-javascript (^6.0.2) ← VULNERABLE
```

## Solution

Added a yarn resolution to force `serialize-javascript>=7.0.3` (the patched version), which overrides the transitive dependency.

```json
"resolutions": {
  "tar": ">=7.5.10",
  "serialize-javascript": ">=7.0.3"
}
```

## Verification

- ✅ `yarn why serialize-javascript` confirms version 7.0.4 is now used
- ✅ All 282 tests pass
- ✅ Build succeeds with webpack
- ✅ Lint passes

## Related

- Resolves: https://github.com/foxglove/omgidl/security/dependabot/54
- Advisory: https://github.com/advisories/GHSA-5c6j-r48x-rmvq
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERT-1920](https://linear.app/foxglove/issue/ERT-1920/resolve-dependabot-alerts-for-serialize-javascript-in-omgidl)

<div><a href="https://cursor.com/agents/bc-e18352c3-90a1-43d1-b338-c855aedf2e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e18352c3-90a1-43d1-b338-c855aedf2e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

