### PR TITLE
fix: resolve Dependabot alert for flatted vulnerability (CVE-2026-32141)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.10"
+    "tar": ">=7.5.10",
+    "flatted": ">=3.4.0"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,10 +3488,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9":
-  version: 3.3.1
-  resolution: "flatted@npm:3.3.1"
-  checksum: 10/7b8376061d5be6e0d3658bbab8bde587647f68797cf6bfeae9dea0e5137d9f27547ab92aaff3512dd9d1299086a6d61be98e9d48a56d17531b634f77faadbc49
+"flatted@npm:>=3.4.0":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [Dependabot alert #58](https://github.com/foxglove/omgidl/security/dependabot/58) for the `flatted` package vulnerability.

## Changes

Added `flatted` to the `resolutions` field in `package.json` to force version `>=3.4.0`, fixing the unbounded recursion DoS vulnerability (CVE-2026-32141) in the `parse()` revive phase.

## Vulnerability Details

- **CVE:** CVE-2026-32141
- **Severity:** High (CVSS 7.5)
- **Package:** `flatted`
- **Affected versions:** < 3.4.0
- **Previous version:** 3.3.1
- **Fixed version:** 3.4.2

## Dependency Chain

```
eslint@9.29.0 → file-entry-cache@8.0.0 → flat-cache@4.0.1 → flatted
```

This is a transitive dev dependency used only for ESLint's caching mechanism.

## Testing

- All tests pass (282 tests across 9 test suites)
- Linting passes successfully

## Related

- Resolves: ERT-1918
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERT-1918](https://linear.app/foxglove/issue/ERT-1918/resolve-dependabot-alerts-for-flatted-in-omgidl)

<div><a href="https://cursor.com/agents/bc-9fdc6cf2-1d4a-4e5a-9a5e-f626e91e7b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fdc6cf2-1d4a-4e5a-9a5e-f626e91e7b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

