### PR TITLE
fix(deps): resolve Dependabot alert for @tootallnate/once (CVE-2026-3449)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.10"
+    "tar": ">=7.5.10",
+    "http-proxy-agent": ">=7.0.0"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,13 +1140,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10/ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.1.14":
   version: 7.20.1
   resolution: "@types/babel__core@npm:7.20.1"
@@ -1835,6 +1828,13 @@ __metadata:
   dependencies:
     debug: "npm:4"
   checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:8.0.0":
+  version: 8.0.0
+  resolution: "agent-base@npm:8.0.0"
+  checksum: 10/a660ae60d389c4ce0f5a178efd5e6ebeefeddf0f6defbb105c638056ec0ebd3828d00d029cf5b26e3ce52d09c393735bf9c187ed1000a0be2c6cf5d95ac15bff
   languageName: node
   linkType: hard
 
@@ -3857,14 +3857,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
+"http-proxy-agent@npm:>=7.0.0":
+  version: 8.0.0
+  resolution: "http-proxy-agent@npm:8.0.0"
   dependencies:
-    "@tootallnate/once": "npm:2"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10/5ee19423bc3e0fd5f23ce991b0755699ad2a46a440ce9cec99e8126bb98448ad3479d2c0ea54be5519db5b19a4ffaa69616bac01540db18506dd4dac3dc418f0
+    agent-base: "npm:8.0.0"
+    debug: "npm:^4.3.4"
+  checksum: 10/ad68856d85c58b654cbe238dc00dde177b5085271e2ff174be65c5b58f6f4e782199683771e8c6b697127620da5dda6643008fd508627414950261a482416347
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR resolves [Dependabot alert #55](https://github.com/foxglove/omgidl/security/dependabot/55) for `@tootallnate/once` vulnerable to CVE-2026-3449 (Incorrect Control Flow Scoping).

## Vulnerability Details

- **CVE:** CVE-2026-3449
- **Severity:** Medium (CVSS v4.0: 4.8)
- **Issue:** When `AbortSignal` option is used, the Promise remains permanently pending after the signal is aborted, causing `await` or `.then()` to hang indefinitely
- **Affected versions:** `@tootallnate/once` < 3.0.1

## Root Cause

The vulnerable package was brought in through this transitive dependency chain:
```
fsevents@2.3.2 (macOS file watcher, used by Jest)
  └── node-gyp@latest (resolved to 9.4.0)
      └── make-fetch-happen@11.1.1
          └── http-proxy-agent@5.0.0
              └── @tootallnate/once@2.0.0 ← VULNERABLE
```

## Solution

Added a resolution override for `http-proxy-agent` to force version `>=7.0.0`. This version no longer depends on `@tootallnate/once`, completely removing the vulnerable package from the dependency tree.

## Changes

- Added `"http-proxy-agent": ">=7.0.0"` to the `resolutions` field in `package.json`
- Updated `yarn.lock` to reflect the resolution

## Verification

- ✅ `@tootallnate/once` is no longer present in `yarn.lock`
- ✅ All tests pass (282 tests across 9 test suites)
- ✅ Build succeeds

## Related

- Resolves [ERT-1919](https://linear.app/foxglove/issue/ERT-1919)
- Fixes [Dependabot alert #55](https://github.com/foxglove/omgidl/security/dependabot/55)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERT-1919](https://linear.app/foxglove/issue/ERT-1919/resolve-dependabot-alerts-for-tootallnateonce-in-omgidl)

<div><a href="https://cursor.com/agents/bc-84650a54-8f70-4f01-9116-310daded05b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84650a54-8f70-4f01-9116-310daded05b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

