### PR TITLE
fix: resolve ajv ReDoS vulnerability (CVE-2025-69873)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.10"
+    "tar": ">=7.5.10",
+    "ajv@^6.12.4": "6.14.0",
+    "ajv@^8.0.0": "8.18.0",
+    "ajv@^8.9.0": "8.18.0"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,27 +1884,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.12.4":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+"ajv@npm:6.14.0":
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10/48d6ad21138d12eb4d16d878d630079a2bda25a04e745c07846a4ad768319533031e28872a9b3c5790fa1ec41aabdf2abed30a56e5a03ebc2cf92184b8ee306c
+  checksum: 10/c71f14dd2b6f2535d043f74019c8169f7aeb1106bafbb741af96f34fdbf932255c919ddd46344043d03b62ea0ccb319f83667ec5eedf612393f29054fe5ce4a5
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.9.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+"ajv@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
+  checksum: 10/bfed9de827a2b27c6d4084324eda76a4e32bdde27410b3e9b81d06e6f8f5c78370fc6b93fe1d869f1939ff1d7c4ae8896960995acb8425e3e9288c8884247c48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR resolves the Dependabot alerts for the `ajv` package by adding yarn resolutions to force patched versions.

**Vulnerability:** CVE-2025-69873 - ReDoS (Regular Expression Denial of Service) vulnerability when using the `$data` option

**Affected alerts:**
- [Alert #43](https://github.com/foxglove/omgidl/security/dependabot/43) - Medium severity
- [Alert #44](https://github.com/foxglove/omgidl/security/dependabot/44) - Medium severity

## Changes

Added yarn resolutions to `package.json` to force patched ajv versions:

| Dependency Range | Previous Version | Fixed Version | Source |
|-----------------|------------------|---------------|--------|
| `ajv@^6.12.4` | 6.12.6 | **6.14.0** | ESLint (transitive) |
| `ajv@^8.0.0` | 8.17.1 | **8.18.0** | Webpack/schema-utils (transitive) |
| `ajv@^8.9.0` | 8.17.1 | **8.18.0** | Webpack/schema-utils (transitive) |

## Notes

- `ajv` is only used as a transitive dependency of dev tools (ESLint and Webpack), not in production code
- The fix uses the same pattern as the existing `tar` resolution in this repo
- All tests pass (282 tests across 3 packages)
- Build and lint checks pass

## Related

Resolves Linear issue ERT-1921
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERT-1921](https://linear.app/foxglove/issue/ERT-1921/resolve-dependabot-alerts-for-ajv-in-omgidl)

<div><a href="https://cursor.com/agents/bc-f3248451-4aa0-472a-aa85-89acc54b467c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3248451-4aa0-472a-aa85-89acc54b467c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

