### PR TITLE
Handle OMG IDL unions without matching cases

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -b ./tsconfig.build.json",
     "lint:ci": "eslint .",
     "lint": "eslint --fix .",
-    "prepack": "yarn build",
+    "prepack": "yarn workspace @foxglove/omgidl-parser build && yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest"
   },

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -346,15 +346,16 @@ export class DeserializationInfoCache {
         const switchValue = switchTypeDefaultGetter() as number | boolean;
 
         defaultCase = unionDef.cases.find((c) => c.predicates.includes(switchValue))?.type;
+        if (!defaultCase) {
+          throw new Error(`Failed to find default case for union ${unionDef.name ?? ""}`);
+        }
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = switchValue;
       } else {
         // default exists, default value of switch case type is not needed
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = undefined;
       }
-      if (defaultCase != undefined) {
-        const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
-        defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
-      }
+      const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
+      defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (deserInfo.type === "struct") {
       for (const field of deserInfo.fieldsInOrder) {

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -346,16 +346,15 @@ export class DeserializationInfoCache {
         const switchValue = switchTypeDefaultGetter() as number | boolean;
 
         defaultCase = unionDef.cases.find((c) => c.predicates.includes(switchValue))?.type;
-        if (!defaultCase) {
-          throw new Error(`Failed to find default case for union ${unionDef.name ?? ""}`);
-        }
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = switchValue;
       } else {
         // default exists, default value of switch case type is not needed
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = undefined;
       }
-      const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
-      defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
+      if (defaultCase != undefined) {
+        const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
+        defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
+      }
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (deserInfo.type === "struct") {
       for (const field of deserInfo.fieldsInOrder) {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -836,6 +836,134 @@ module builtin_interfaces {
       },
     });
   });
+
+  it("continues reading a mutable struct after a union discriminator has no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 0:
+            @id(100)
+            uint8 rgb[3];
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(true, 5, 6); // writes emHeader for color field
+
+    writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
+    writer.uint8(0x09); // discriminator has no matching case
+
+    // absent value because discriminator doesn't exist
+
+    writer.sentinelHeader(); // end union
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    writer.sentinelHeader(); // end struct
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 9,
+      },
+      marker: 77,
+    });
+  });
+
+  it("continues reading an XCDR2 mutable struct after a union discriminator has no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 0:
+            @id(100)
+            uint8 rgb[3];
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(21); // color header + union body + marker alignment/header/value
+    writer.emHeader(true, 5, 5, 5); // writes emHeader for color field
+
+    writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
+    writer.uint8(0x09); // discriminator has no matching case
+
+    // absent value because discriminator doesn't exist
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 9,
+      },
+      marker: 77,
+    });
+  });
+
+  it("uses a discriminator-only default for a missing non-optional union with no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 1:
+            @id(100)
+            uint8 red;
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    writer.sentinelHeader(); // end struct
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      marker: 77,
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
+      },
+    });
+  });
+
   it("Reads array from mutable union field", () => {
     const msgDef = `
         @mutable

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -926,44 +926,6 @@ module builtin_interfaces {
     });
   });
 
-  it("uses a discriminator-only default for a missing non-optional union with no matching case or default", () => {
-    const msgDef = `
-        @mutable
-        union ColorOrGray switch (uint8) {
-          case 1:
-            @id(100)
-            uint8 red;
-          case 3:
-            @id(200)
-            uint8 gray;
-        };
-        @mutable
-        struct Fence {
-            @id(5) ColorOrGray color;
-            @id(6) uint8 marker;
-        };
-    `;
-
-    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-
-    writer.emHeader(true, 6, 1); // writes emHeader for marker field
-    writer.uint8(77);
-
-    writer.sentinelHeader(); // end struct
-
-    const rootDef = "Fence";
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-
-    const msgout = reader.readMessage(writer.data);
-
-    expect(msgout).toEqual({
-      marker: 77,
-      color: {
-        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
-      },
-    });
-  });
-
   it("Reads array from mutable union field", () => {
     const msgDef = `
         @mutable

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -237,6 +237,7 @@ export class MessageReader<T = unknown> {
 
     // if no matching case and no default case, only return discriminator value
     if (!fieldDeserInfo || !caseDefType) {
+      this.finishUnionWithoutCase(reader, { usesMemberHeader, usesDelimiterHeader }, typeEndOffset);
       return {
         [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       };
@@ -304,6 +305,21 @@ export class MessageReader<T = unknown> {
       [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       [caseDefType.name]: caseDefValue,
     };
+  }
+
+  /**
+   * Advances the reader past a union that has no active member for its discriminator.
+   */
+  private finishUnionWithoutCase(
+    reader: CdrReader,
+    headerOptions: HeaderOptions,
+    typeEndOffset: number | undefined,
+  ): void {
+    if (typeEndOffset != undefined) {
+      reader.seekTo(typeEndOffset);
+    } else if (headerOptions.usesMemberHeader && !headerOptions.usesDelimiterHeader) {
+      reader.sentinelHeader();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Advance past union boundaries when an encoded discriminator has no matching case and no default value.
- Preserve the discriminator-only union value and continue reading following fields.
- Add regression coverage for both XCDR1 and XCDR2 discriminator-only union reads.

## Example addressed
This handles a mutable union where the encoded discriminator is valid for the switch type, but has no associated case and the union has no `default` member:

```idl
enum TriggerType {
  kInvalidTriggerType,
  kTimeTrigger,
  kHumanDetectionTrigger,
  kGrayhillSsmTrigger,
  kManualInterventionTrigger
};

@mutable
union TriggerContent switch(TriggerType) {
  case kTimeTrigger:
    @id(100) TimeTrigger time_trigger;
  case kHumanDetectionTrigger:
    @id(200) HumanDetectionTrigger human_detection_trigger;
  case kManualInterventionTrigger:
    @id(400) ManualInterventionTrigger manual_intervention_trigger;
};
```

For a message encoded with `TriggerContent` discriminator `kInvalidTriggerType` or `kGrayhillSsmTrigger`, deserialization should preserve the discriminator, skip the union boundary, and continue reading following fields instead of trying to read a nonexistent member.

## Test plan
- yarn workspace @foxglove/omgidl-serialization test MessageReader.test.ts --runInBand