### PR TITLE
Skip union members when discriminator is unmatched

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -b ./tsconfig.build.json",
     "lint:ci": "eslint .",
     "lint": "eslint --fix .",
-    "prepack": "yarn build",
+    "prepack": "yarn workspace @foxglove/omgidl-parser build && yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest"
   },

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -b ./tsconfig.build.json",
     "lint:ci": "eslint .",
     "lint": "eslint --fix .",
-    "prepack": "yarn workspace @foxglove/omgidl-parser build && yarn build",
+    "prepack": "yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest"
   },

--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -36,7 +36,7 @@
     "build": "tsc -b ./tsconfig.build.json",
     "lint:ci": "eslint .",
     "lint": "eslint --fix .",
-    "prepack": "yarn build",
+    "prepack": "yarn workspace @foxglove/omgidl-parser run build && yarn build",
     "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest"
   },

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -346,15 +346,16 @@ export class DeserializationInfoCache {
         const switchValue = switchTypeDefaultGetter() as number | boolean;
 
         defaultCase = unionDef.cases.find((c) => c.predicates.includes(switchValue))?.type;
+        if (!defaultCase) {
+          throw new Error(`Failed to find default case for union ${unionDef.name ?? ""}`);
+        }
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = switchValue;
       } else {
         // default exists, default value of switch case type is not needed
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = undefined;
       }
-      if (defaultCase != undefined) {
-        const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
-        defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
-      }
+      const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
+      defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (deserInfo.type === "struct") {
       for (const field of deserInfo.fieldsInOrder) {

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -346,16 +346,15 @@ export class DeserializationInfoCache {
         const switchValue = switchTypeDefaultGetter() as number | boolean;
 
         defaultCase = unionDef.cases.find((c) => c.predicates.includes(switchValue))?.type;
-        if (!defaultCase) {
-          throw new Error(`Failed to find default case for union ${unionDef.name ?? ""}`);
-        }
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = switchValue;
       } else {
         // default exists, default value of switch case type is not needed
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = undefined;
       }
-      const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
-      defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
+      if (defaultCase != undefined) {
+        const defaultCaseDeserInfo = this.buildFieldDeserInfo(defaultCase);
+        defaultMessage[defaultCaseDeserInfo.name] = this.getFieldDefault(defaultCaseDeserInfo);
+      }
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (deserInfo.type === "struct") {
       for (const field of deserInfo.fieldsInOrder) {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -927,6 +927,8 @@ module builtin_interfaces {
     writer.emHeader(true, 200, 1); // emHeader for unknown field
     writer.uint8(100); // unknown field value
 
+    // don't emit marker, to see that the above field with same ID is skipped
+
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -836,6 +836,134 @@ module builtin_interfaces {
       },
     });
   });
+
+  it("continues reading a mutable struct after a union discriminator has no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 0:
+            @id(100)
+            uint8 rgb[3];
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(true, 5, 6); // writes emHeader for color field
+
+    writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
+    writer.uint8(0x09); // discriminator has no matching case
+
+    // absent value because discriminator doesn't exist
+
+    writer.sentinelHeader(); // end union
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    writer.sentinelHeader(); // end struct
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 9,
+      },
+      marker: 77,
+    });
+  });
+
+  it("continues reading an XCDR2 mutable struct after a union discriminator has no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 0:
+            @id(100)
+            uint8 rgb[3];
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(21); // color header + union body + marker alignment/header/value
+    writer.emHeader(true, 5, 5, 5); // writes emHeader for color field
+
+    writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
+    writer.uint8(0x09); // discriminator has no matching case
+
+    // absent value because discriminator doesn't exist
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 9,
+      },
+      marker: 77,
+    });
+  });
+
+  it("uses a discriminator-only default for a missing non-optional union with no matching case or default", () => {
+    const msgDef = `
+        @mutable
+        union ColorOrGray switch (uint8) {
+          case 1:
+            @id(100)
+            uint8 red;
+          case 3:
+            @id(200)
+            uint8 gray;
+        };
+        @mutable
+        struct Fence {
+            @id(5) ColorOrGray color;
+            @id(6) uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+
+    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.uint8(77);
+
+    writer.sentinelHeader(); // end struct
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      marker: 77,
+      color: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
+      },
+    });
+  });
+
   it("Reads array from mutable union field", () => {
     const msgDef = `
         @mutable

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -837,7 +837,7 @@ module builtin_interfaces {
     });
   });
 
-  it("continues reading a mutable struct after a union discriminator has no matching case or default", () => {
+  it("skips over body of an XCDR1 mutable union after finding an unknown discriminator", () => {
     const msgDef = `
         @mutable
         union ColorOrGray switch (uint8) {
@@ -856,7 +856,16 @@ module builtin_interfaces {
     `;
 
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-    writer.emHeader(true, 5, 6); // writes emHeader for color field
+    // emheader for color field
+    writer.emHeader(
+      true,
+      5,
+      4 /* discriminator emheader */ +
+        1 /* discriminator */ +
+        1 /* padding */ +
+        2 /* sentinel start */ +
+        2 /* sentinel length */,
+    );
 
     writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
     writer.uint8(0x09); // discriminator has no matching case
@@ -883,7 +892,7 @@ module builtin_interfaces {
     });
   });
 
-  it("continues reading an XCDR2 mutable struct after a union discriminator has no matching case or default", () => {
+  it("skips over body of an XCDR2 mutable union after finding an unknown discriminator", () => {
     const msgDef = `
         @mutable
         union ColorOrGray switch (uint8) {
@@ -891,27 +900,32 @@ module builtin_interfaces {
             @id(100)
             uint8 rgb[3];
           case 3:
-            @id(200)
+            @id(500)
             uint8 gray;
         };
         @mutable
         struct Fence {
-            @id(5) ColorOrGray color;
-            @id(6) uint8 marker;
+            @id(100) ColorOrGray color;
+            @id(200) uint8 marker;
         };
     `;
 
     const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
-    writer.dHeader(21); // color header + union body + marker alignment/header/value
-    writer.emHeader(true, 5, 5, 5); // writes emHeader for color field
+    const colorSize =
+      4 /* discriminator emheader */ +
+      1 /* discriminator */ +
+      3 /* padding */ +
+      4 /* unknown field emheader */ +
+      1; /* unknown field */
+    writer.dHeader(4 /* color emheader */ + colorSize);
 
+    // color field
+    writer.emHeader(true, 100, colorSize, 5); // emHeader for color field
+    // union
     writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
     writer.uint8(0x09); // discriminator has no matching case
-
-    // absent value because discriminator doesn't exist
-
-    writer.emHeader(true, 6, 1); // writes emHeader for marker field
-    writer.uint8(77);
+    writer.emHeader(true, 200, 1); // emHeader for unknown field
+    writer.uint8(100); // unknown field value
 
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
@@ -922,7 +936,7 @@ module builtin_interfaces {
       color: {
         [UNION_DISCRIMINATOR_PROPERTY_KEY]: 9,
       },
-      marker: 77,
+      marker: 0,
     });
   });
 

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -845,13 +845,13 @@ module builtin_interfaces {
             @id(100)
             uint8 rgb[3];
           case 3:
-            @id(200)
+            @id(500)
             uint8 gray;
         };
         @mutable
         struct Fence {
-            @id(5) ColorOrGray color;
-            @id(6) uint8 marker;
+            @id(100) ColorOrGray color;
+            @id(200) uint8 marker;
         };
     `;
 
@@ -859,10 +859,13 @@ module builtin_interfaces {
     // emheader for color field
     writer.emHeader(
       true,
-      5,
+      100,
       4 /* discriminator emheader */ +
         1 /* discriminator */ +
-        1 /* padding */ +
+        3 /* padding */ +
+        4 /* unknown field emheader */ +
+        1 /* unknown field */ +
+        3 /* padding */ +
         2 /* sentinel start */ +
         2 /* sentinel length */,
     );
@@ -870,11 +873,12 @@ module builtin_interfaces {
     writer.emHeader(true, 1, 1); // emHeader for discriminator (switch type)
     writer.uint8(0x09); // discriminator has no matching case
 
-    // absent value because discriminator doesn't exist
+    writer.emHeader(true, 200, 1); // emHeader for unknown field
+    writer.uint8(100); // unknown field value
 
     writer.sentinelHeader(); // end union
 
-    writer.emHeader(true, 6, 1); // writes emHeader for marker field
+    writer.emHeader(true, 200, 1); // writes emHeader for marker field
     writer.uint8(77);
 
     writer.sentinelHeader(); // end struct
@@ -940,6 +944,34 @@ module builtin_interfaces {
       },
       marker: 0,
     });
+  });
+
+  it("throws if union's case is unknown and its length is indeterminate", () => {
+    const msgDef = `
+        @final
+        union ColorOrGray switch (uint8) {
+          case 0:
+            uint8 rgb[3];
+        };
+
+        @final
+        struct Fence {
+            ColorOrGray color;
+            uint8 marker;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.CDR_LE });
+    writer.uint8(0x09); // discriminator has no matching case
+    writer.uint8(100); // unknown field value
+    writer.uint8(77); // marker value
+
+    const rootDef = "Fence";
+    const reader = new MessageReader(rootDef, parseIDL(msgDef));
+
+    expect(() => reader.readMessage(writer.data)).toThrow(
+      "union's case is unknown, but cannot skip its body because its length is indeterminate",
+    );
   });
 
   it("Reads array from mutable union field", () => {

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -926,44 +926,6 @@ module builtin_interfaces {
     });
   });
 
-  it("uses a discriminator-only default for a missing non-optional union with no matching case or default", () => {
-    const msgDef = `
-        @mutable
-        union ColorOrGray switch (uint8) {
-          case 1:
-            @id(100)
-            uint8 red;
-          case 3:
-            @id(200)
-            uint8 gray;
-        };
-        @mutable
-        struct Fence {
-            @id(5) ColorOrGray color;
-            @id(6) uint8 marker;
-        };
-    `;
-
-    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
-
-    writer.emHeader(true, 6, 1); // writes emHeader for marker field
-    writer.uint8(77);
-
-    writer.sentinelHeader(); // end struct
-
-    const rootDef = "Fence";
-    const reader = new MessageReader(rootDef, parseIDL(msgDef));
-
-    const msgout = reader.readMessage(writer.data);
-
-    expect(msgout).toEqual({
-      marker: 77,
-      color: {
-        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
-      },
-    });
-  });
-
   it("Reads array from mutable union field", () => {
     const msgDef = `
         @mutable

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -116,6 +116,7 @@ export class MessageReader<T = unknown> {
         }
 
         const { objectSize, id, readSentinelHeader, lengthCode } = reader.emHeader();
+        console.log("emHeader", { objectSize, id, readSentinelHeader, lengthCode });
 
         // end of struct, this accounts for XCDR1 mutable structs
         if (readSentinelHeader === true) {
@@ -215,6 +216,10 @@ export class MessageReader<T = unknown> {
     // unions print an emHeader for the switchType
     if (usesMemberHeader) {
       const { objectSize: objectSizeBytes } = reader.emHeader();
+      console.log("emHeader", {
+        objectSize: objectSizeBytes,
+        switchTypeLength: deserInfo.switchTypeLength,
+      });
       if (objectSizeBytes !== deserInfo.switchTypeLength) {
         throw new Error(
           `Expected switchType length of ${
@@ -224,7 +229,7 @@ export class MessageReader<T = unknown> {
       }
     }
     const discriminatorValue = deserInfo.switchTypeDeser(reader) as number | boolean;
-
+    console.log("discriminatorValue", discriminatorValue);
     // Discriminator case determination: Section 7.4.1.4.4.4.2 of https://www.omg.org/spec/IDL/4.2/PDF
     // get case for switchtype value based on matching predicate
     let caseDefType = getCaseForDiscriminator(deserInfo.definition, discriminatorValue);
@@ -235,9 +240,34 @@ export class MessageReader<T = unknown> {
       ? this.deserializationInfoCache.buildFieldDeserInfo(caseDefType)
       : undefined;
 
+    const hasSentinelHeader = !usesDelimiterHeader && usesMemberHeader; // XCDR1 mutable
+
     // if no matching case and no default case, only return discriminator value
     if (!fieldDeserInfo || !caseDefType) {
-      this.finishUnionWithoutCase(reader, { usesMemberHeader, usesDelimiterHeader }, typeEndOffset);
+      if (typeEndOffset != undefined) {
+        reader.seekTo(typeEndOffset);
+      } else if (hasSentinelHeader) {
+        for (;;) {
+          const { objectSize, readSentinelHeader } = reader.emHeader();
+          // This is PL_CDR, so objectSize is the byte length of the member
+          // body.
+          //
+          // From DDS-XTypes v1.3, section 7.4.1.2 Parameterized CDR Encoding:
+          //
+          // > Unlike it is stated in [RTPS] Sub Clause 9.4.2.11
+          // > “ParameterList”, the value of the parameter length is the exact
+          // > length of the serialized member.
+          reader.seek(objectSize); //
+          if (readSentinelHeader === true) {
+            break;
+          }
+        }
+      } else {
+        throw new Error(
+          "union's case is unknown, but cannot skip its body because its length is indeterminate",
+        );
+      }
+
       return {
         [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       };
@@ -247,7 +277,6 @@ export class MessageReader<T = unknown> {
 
     // even if the union is ended we need to set the defaults
     if (usesMemberHeader) {
-      const needsToReadSentinelHeader = !usesDelimiterHeader && usesMemberHeader; // XCDR1 mutable
       // MUTABLE UNION
       const atEndOfUnion = typeEndOffset != undefined && reader.offset >= typeEndOffset;
       const emHeader = !atEndOfUnion ? reader.emHeader() : undefined;
@@ -274,7 +303,7 @@ export class MessageReader<T = unknown> {
           },
           options,
         );
-        if (needsToReadSentinelHeader) {
+        if (hasSentinelHeader) {
           reader.sentinelHeader();
         }
       }
@@ -305,21 +334,6 @@ export class MessageReader<T = unknown> {
       [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       [caseDefType.name]: caseDefValue,
     };
-  }
-
-  /**
-   * Advances the reader past a union that has no active member for its discriminator.
-   */
-  private finishUnionWithoutCase(
-    reader: CdrReader,
-    headerOptions: HeaderOptions,
-    typeEndOffset: number | undefined,
-  ): void {
-    if (typeEndOffset != undefined) {
-      reader.seekTo(typeEndOffset);
-    } else if (headerOptions.usesMemberHeader && !headerOptions.usesDelimiterHeader) {
-      reader.sentinelHeader();
-    }
   }
 
   /**

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -116,7 +116,6 @@ export class MessageReader<T = unknown> {
         }
 
         const { objectSize, id, readSentinelHeader, lengthCode } = reader.emHeader();
-        console.log("emHeader", { objectSize, id, readSentinelHeader, lengthCode });
 
         // end of struct, this accounts for XCDR1 mutable structs
         if (readSentinelHeader === true) {
@@ -216,10 +215,6 @@ export class MessageReader<T = unknown> {
     // unions print an emHeader for the switchType
     if (usesMemberHeader) {
       const { objectSize: objectSizeBytes } = reader.emHeader();
-      console.log("emHeader", {
-        objectSize: objectSizeBytes,
-        switchTypeLength: deserInfo.switchTypeLength,
-      });
       if (objectSizeBytes !== deserInfo.switchTypeLength) {
         throw new Error(
           `Expected switchType length of ${
@@ -229,7 +224,6 @@ export class MessageReader<T = unknown> {
       }
     }
     const discriminatorValue = deserInfo.switchTypeDeser(reader) as number | boolean;
-    console.log("discriminatorValue", discriminatorValue);
     // Discriminator case determination: Section 7.4.1.4.4.4.2 of https://www.omg.org/spec/IDL/4.2/PDF
     // get case for switchtype value based on matching predicate
     let caseDefType = getCaseForDiscriminator(deserInfo.definition, discriminatorValue);

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -237,6 +237,7 @@ export class MessageReader<T = unknown> {
 
     // if no matching case and no default case, only return discriminator value
     if (!fieldDeserInfo || !caseDefType) {
+      this.finishUnionWithoutCase(reader, { usesMemberHeader, usesDelimiterHeader }, typeEndOffset);
       return {
         [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       };
@@ -304,6 +305,21 @@ export class MessageReader<T = unknown> {
       [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       [caseDefType.name]: caseDefValue,
     };
+  }
+
+  /**
+   * Advances the reader past a union that has no active member for its discriminator.
+   */
+  private finishUnionWithoutCase(
+    reader: CdrReader,
+    headerOptions: HeaderOptions,
+    typeEndOffset: number | undefined,
+  ): void {
+    if (typeEndOffset != undefined) {
+      reader.seekTo(typeEndOffset);
+    } else if (headerOptions.usesMemberHeader && !headerOptions.usesDelimiterHeader) {
+      reader.sentinelHeader();
+    }
   }
 
   /**

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -251,7 +251,7 @@ export class MessageReader<T = unknown> {
           // > Unlike it is stated in [RTPS] Sub Clause 9.4.2.11
           // > “ParameterList”, the value of the parameter length is the exact
           // > length of the serialized member.
-          reader.seek(objectSize); //
+          reader.seek(objectSize);
           if (readSentinelHeader === true) {
             break;
           }


### PR DESCRIPTION
### Changelog
Fix corrupted read when a union discriminator does not match any case in the union's definition.

### Docs
None

### Description

`MessageReader` silently produces corrupted data if it encounters an unknown union discriminator.

This is because it leaves the read cursor in place just after the discriminator, causing the caller to believe it finished reading the union. The caller would then start reading its next data from the middle of the union member.

In this PR, we instead skip the rest of the union if possible, or throw an error if not.

Tests have been added to cover this with mutable and final types. I've checked that they all fail without these changes.

Fixes: FG-14472