### PR TITLE
Bump omgidl-serialization to v1.2.4

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description

Bump the version to include the latest fix.

