### PR TITLE
Update fast-uri for CVE fixes

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,9 +3434,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.0.6
-  resolution: "fast-uri@npm:3.0.6"
-  checksum: 10/43c87cd03926b072a241590e49eca0e2dfe1d347ddffd4b15307613b42b8eacce00a315cf3c7374736b5f343f27e27ec88726260eb03a758336d507d6fbaba0a
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10/1dff04865b2a38d3e0659deadfbf72efdf83a776bfbf9667e4aa9e5a3ec31bc341cda9622136b32b7652a857c8ba11896794186e8f876f8b2b72731fce8622f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes FG-14762.

Updates the transitive `fast-uri` lockfile resolution from `3.0.6` to `3.1.2` to remediate CVE-2026-6321 and CVE-2026-6322.

Validation:
- `corepack yarn build`
- `corepack yarn lint:ci`
- `corepack yarn test`

Note: the first `corepack yarn test` run failed before build because serialization tests could not resolve the parser workspace output; after `corepack yarn build`, the same test command passed.
