### PR TITLE
Add message reader debug method which shows decodes up to error

### DIFF
--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -15,6 +15,17 @@ const float32Buffer = (floats: number[]): Uint8Array => {
   return new Uint8Array(Float32Array.from(floats).buffer);
 };
 
+// Routes every read through the debugging path (readMessageDebug) so these tests also exercise the
+// partial-state capture. On success it returns the decoded message; on failure it rethrows the
+// captured error so error-path assertions (e.g. toThrow) behave exactly like readMessage.
+function readMessageWithDebug(reader: MessageReader, buffer: ArrayBufferView): unknown {
+  const result = reader.readMessageDebug(buffer);
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.message;
+}
+
 describe("MessageReader", () => {
   it("simple test", () => {
     const msgDef = `module a {
@@ -307,7 +318,7 @@ describe("MessageReader", () => {
     (msgDef: string, rootDef: string, arr: Iterable<number>, expected: Record<string, unknown>) => {
       const buffer = Uint8Array.from([0, 1, 0, 0, ...arr]);
       const reader = new MessageReader(rootDef, parseIDL(msgDef));
-      const read = reader.readMessage(buffer);
+      const read = readMessageWithDebug(reader, buffer);
 
       // check that our message matches the object
       expect(read).toEqual(expected);
@@ -391,7 +402,7 @@ module builtin_interfaces {
 };
     `;
     const reader = new MessageReader("geometry_msgs::msg::Transforms", parseIDL(msgDef));
-    const read = reader.readMessage(buffer);
+    const read = readMessageWithDebug(reader, buffer);
 
     expect(read).toEqual({
       transforms: [
@@ -454,7 +465,7 @@ module builtin_interfaces {
     const rootDef = "Address";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({ pointer: 15 });
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({ pointer: 15 });
   });
 
   it("reads simple nested mutable struct", () => {
@@ -493,7 +504,7 @@ module builtin_interfaces {
     const rootDef = "Person";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       heightMeters: 1.8,
       address: { pointer: 15 },
       age: 30,
@@ -517,7 +528,7 @@ module builtin_interfaces {
     const rootDef = "Address";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({ pointer: 15 });
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({ pointer: 15 });
   });
 
   it("PL_CDRv1: reads simple nested mutable struct", () => {
@@ -558,7 +569,7 @@ module builtin_interfaces {
     const rootDef = "Person";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       heightMeters: 1.8,
       address: { pointer: 15 },
       age: 30,
@@ -602,7 +613,7 @@ module builtin_interfaces {
     const rootDef = "Plot";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       name: "MPG",
       xValues: new Float64Array([1, 2, 3]),
       yValues: new Float64Array([4, 5, 6]),
@@ -646,7 +657,7 @@ module builtin_interfaces {
     const rootDef = "Plot";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       name: "MPG",
       xValues: new Float64Array([1, 2, 3]),
       yValues: new Float64Array([4, 5, 6]),
@@ -677,7 +688,7 @@ module builtin_interfaces {
 
     const rootDef = "Grid";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       table: [new Float32Array([1, 2, 3]), new Float32Array([4, 5, 6])],
     });
   });
@@ -702,7 +713,7 @@ module builtin_interfaces {
     const rootDef = "Array";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(reader.readMessage(writer.data)).toEqual({
+    expect(readMessageWithDebug(reader, writer.data)).toEqual({
       numbers: new Float64Array([]),
     });
   });
@@ -746,7 +757,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -788,7 +799,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -828,7 +839,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -886,7 +897,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -936,7 +947,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -969,7 +980,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    expect(() => reader.readMessage(writer.data)).toThrow(
+    expect(() => readMessageWithDebug(reader, writer.data)).toThrow(
       "union's case is unknown, but cannot skip its body because its length is indeterminate",
     );
   });
@@ -1006,7 +1017,7 @@ module builtin_interfaces {
     const rootDef = "Fence";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual({
       color: {
@@ -1045,7 +1056,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1071,7 +1082,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1097,7 +1108,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1123,7 +1134,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1149,7 +1160,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1183,7 +1194,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1216,7 +1227,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1249,7 +1260,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1286,7 +1297,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1323,7 +1334,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1358,7 +1369,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1393,7 +1404,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1430,7 +1441,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1467,7 +1478,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1502,7 +1513,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1537,7 +1548,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1551,7 +1562,7 @@ module builtin_interfaces {
 
     const rootDef = "Message";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
     expect(msgout).toEqual(data);
   });
   it("Reads mutable struct with absent inner struct member at the end using PL_CDR2", () => {
@@ -1583,7 +1594,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1615,7 +1626,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1646,7 +1657,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1662,7 +1673,7 @@ module builtin_interfaces {
 
     const rootDef = "Message";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
     expect(msgout).toEqual(data);
   });
   it("Reads appendable struct with complex inner sequence", () => {
@@ -1691,7 +1702,7 @@ module builtin_interfaces {
 
     const rootDef = "Outer";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(buffer);
+    const msgout = readMessageWithDebug(reader, buffer);
     expect(msgout).toEqual(data);
   });
   it("Reads appendable struct with primitive inner sequence", () => {
@@ -1714,7 +1725,7 @@ module builtin_interfaces {
 
     const rootDef = "Outer";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(buffer);
+    const msgout = readMessageWithDebug(reader, buffer);
     expect(msgout).toEqual(data);
   });
   it("Reads an XCDR2-encoded struct with unspecified extensibility as if it were appendable", () => {
@@ -1731,7 +1742,7 @@ module builtin_interfaces {
     writer.uint8(data.a);
     const rootDef = "X";
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
     expect(msgout).toEqual(data);
   });
   it("Reads XCDR1 appendable struct", () => {
@@ -1758,7 +1769,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1786,7 +1797,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
   });
@@ -1817,7 +1828,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -1849,7 +1860,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -1879,7 +1890,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -1909,7 +1920,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -1943,7 +1954,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -1977,7 +1988,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -2012,7 +2023,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -2046,7 +2057,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -2078,7 +2089,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(data);
     expect(reader.lastMessageBufferEndReached()).toBe(true);
@@ -2130,7 +2141,7 @@ module builtin_interfaces {
 
     const reader = new MessageReader(rootDef, parseIDL(msgDef));
 
-    const msgout = reader.readMessage(writer.data);
+    const msgout = readMessageWithDebug(reader, writer.data);
 
     expect(msgout).toEqual(expected);
     expect(reader.lastMessageBufferEndReached()).toBe(true);

--- a/packages/omgidl-serialization/src/MessageReader.ts
+++ b/packages/omgidl-serialization/src/MessageReader.ts
@@ -16,12 +16,50 @@ import {
 } from "./DeserializationInfoCache";
 import { UNION_DISCRIMINATOR_PROPERTY_KEY } from "./constants";
 
+/**
+ * A single level of type nesting captured while decoding, ordered from the root type down to the
+ * type being decoded when an error occurred. `value` is a live reference to the partially-filled
+ * message object, so it reflects every field that was decoded before the failure.
+ */
+export type DecodeDebugFrame = {
+  /** Name of the struct or union definition being decoded at this level. */
+  type: string;
+  /** The partially-decoded message object for this level. */
+  value: Record<string, unknown>;
+};
+
+/** Result of {@link MessageReader.readMessageDebug}. */
+export type DecodeDebugResult<R> =
+  | { ok: true; message: R }
+  | {
+      ok: false;
+      /** The error that stopped decoding. */
+      error: Error;
+      /** Byte offset within the buffer where decoding stopped, if known. */
+      offset?: number;
+      /** Type nesting from the root type to the deepest type being decoded, each with its partial value. */
+      stack: DecodeDebugFrame[];
+    };
+
+/**
+ * Opt-in debugging state. Holds the stack of partially-decoded messages so it can be inspected if
+ * decoding throws. Debugging aid only; populated solely by {@link MessageReader.readMessageDebug}.
+ */
+type DecodeDebugState = {
+  stack: DecodeDebugFrame[];
+  /** CDR reader that is reading the current message. Needs to store it to report the offset information. */
+  reader?: CdrReader;
+};
+
 export class MessageReader<T = unknown> {
   rootDeserializationInfo: ComplexDeserializationInfo;
   deserializationInfoCache: DeserializationInfoCache;
   /** Used for debugging. We do not error if the buffer end is not reached because it is possible this could cause
    * unexpected errors with user data. */
   #lastMessageBufferEndReached = false;
+  /** Opt-in debugging state, only set while {@link readMessageDebug} is running. When undefined
+   * (the production path) all debug bookkeeping is skipped and deserialization is unaffected. */
+  #debug?: DecodeDebugState;
 
   constructor(rootDefinitionName: string, definitions: IDLMessageDefinition[]) {
     const rootDefinition = definitions.find((def) => def.name === rootDefinitionName);
@@ -42,6 +80,9 @@ export class MessageReader<T = unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
+    if (this.#debug != undefined) {
+      this.#debug.reader = reader;
+    }
     // if true means that it is definitely using CDR2 (however doesn't apply to CDR2 Final (non PL_CDR and non DELIMITED_CDR2))
     const usesDelimiterHeader = reader.usesDelimiterHeader;
     const usesMemberHeader = reader.usesMemberHeader;
@@ -56,8 +97,45 @@ export class MessageReader<T = unknown> {
     return res;
   }
 
+  /**
+   * Decodes a message like {@link readMessage}, but if decoding throws it returns the partial decode
+   * state instead of discarding it. The result reports how far decoding progressed: the
+   * partially-decoded message tree at each level of type nesting, the byte offset where decoding
+   * stopped, and the error.
+   *
+   * This is strictly a debugging aid. It does not change deserialization behavior and is not meant
+   * for production decode paths.
+   */
+  readMessageDebug<R = T>(buffer: ArrayBufferView): DecodeDebugResult<R> {
+    this.#debug = { stack: [] };
+    try {
+      const message = this.readMessage<R>(buffer);
+      return { ok: true, message };
+    } catch (err: unknown) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+        offset: this.#debug.reader?.offset,
+        stack: this.#debug.stack,
+      };
+    } finally {
+      this.#debug = undefined;
+    }
+  }
+
   public lastMessageBufferEndReached(): boolean {
     return this.#lastMessageBufferEndReached;
+  }
+
+  /** Pushes a partial message onto the debug stack. No-op unless debugging is enabled. */
+  #debugEnter(deserInfo: ComplexDeserializationInfo, value: Record<string, unknown>): void {
+    this.#debug?.stack.push({ type: deserInfo.definition.name ?? "<unnamed>", value });
+  }
+
+  /** Pops the current partial message off the debug stack on a successful read. No-op unless
+   * debugging is enabled. On an error the frame is intentionally left in place for inspection. */
+  #debugExit(): void {
+    this.#debug?.stack.pop();
   }
 
   private readAggregatedType(
@@ -97,6 +175,7 @@ export class MessageReader<T = unknown> {
     const usesDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
 
     const msg: Record<string, unknown> = {};
+    this.#debugEnter(deserInfo, msg);
 
     // There's a few ways we should be reading structs
     // 1. Struct is mutable. It has a typeEndOffset. Read based off each EMHEADER. Meaning that we need to read the EMHEADER to determine what the field is and then use the emHeader to read the field.
@@ -200,6 +279,7 @@ export class MessageReader<T = unknown> {
         );
       }
     } // END OF APPENDABLE OR FINAL STRUCT
+    this.#debugExit();
     return msg;
   }
 
@@ -211,6 +291,13 @@ export class MessageReader<T = unknown> {
   ): Record<string, unknown> {
     const usesMemberHeader = options.usesMemberHeader && deserInfo.usesMemberHeader;
     const usesDelimiterHeader = options.usesDelimiterHeader && deserInfo.usesDelimiterHeader;
+
+    // Debug-only running view of the union, populated with the discriminator as it is decoded so the
+    // partial state is meaningful if a later read throws. Not created on the production path.
+    const debugValue: Record<string, unknown> | undefined = this.#debug ? {} : undefined;
+    if (debugValue) {
+      this.#debugEnter(deserInfo, debugValue);
+    }
 
     // unions print an emHeader for the switchType
     if (usesMemberHeader) {
@@ -229,6 +316,10 @@ export class MessageReader<T = unknown> {
     let caseDefType = getCaseForDiscriminator(deserInfo.definition, discriminatorValue);
     // If no case is found, use the default case
     caseDefType ??= deserInfo.definition.defaultCase;
+
+    if (debugValue) {
+      debugValue[UNION_DISCRIMINATOR_PROPERTY_KEY] = discriminatorValue;
+    }
 
     const fieldDeserInfo = caseDefType
       ? this.deserializationInfoCache.buildFieldDeserInfo(caseDefType)
@@ -262,6 +353,7 @@ export class MessageReader<T = unknown> {
         );
       }
 
+      this.#debugExit();
       return {
         [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       };
@@ -324,6 +416,7 @@ export class MessageReader<T = unknown> {
       }
     }
 
+    this.#debugExit();
     return {
       [UNION_DISCRIMINATOR_PROPERTY_KEY]: discriminatorValue,
       [caseDefType.name]: caseDefValue,

--- a/packages/omgidl-serialization/src/debugReadMessage.ts
+++ b/packages/omgidl-serialization/src/debugReadMessage.ts
@@ -1,0 +1,74 @@
+import { DecodeDebugResult, MessageReader } from "./MessageReader";
+
+type DecodeFailure = Extract<DecodeDebugResult<unknown>, { ok: false }>;
+
+/**
+ * `JSON.stringify` replacer that renders decoded values which are otherwise not serializable:
+ * BigInts become strings and typed arrays / array buffer views become plain number arrays.
+ */
+export function debugJsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (ArrayBuffer.isView(value)) {
+    return Array.from(value as unknown as ArrayLike<number>);
+  }
+  return value;
+}
+
+/**
+ * Formats the partial decode state captured by {@link MessageReader.readMessageDebug} into a
+ * human-readable report describing how far decoding progressed before the reader threw.
+ *
+ * @param failure The failing result returned by {@link MessageReader.readMessageDebug}.
+ * @returns A multi-line report with the error, the nesting path of types, and the partially-decoded
+ * message at each level (the last entry is the type that was being decoded when the error occurred).
+ */
+export function formatDecodeDebugReport(failure: DecodeFailure): string {
+  const lines: string[] = [];
+  const offsetText = failure.offset != undefined ? ` at byte offset ${failure.offset}` : "";
+  lines.push(`MessageReader failed${offsetText}: ${failure.error.message}`);
+
+  if (failure.stack.length > 0) {
+    lines.push("");
+    lines.push("Decode path (root -> failure):");
+    failure.stack.forEach((frame, depth) => {
+      lines.push(`  ${"  ".repeat(depth)}${frame.type}`);
+    });
+
+    lines.push("");
+    lines.push("Partial decode state (each level, last is where it failed):");
+    lines.push(JSON.stringify(failure.stack, debugJsonReplacer, 2));
+  } else {
+    lines.push("");
+    lines.push(
+      "No partial decode state was captured (failed before decoding any aggregated type).",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/** Result of {@link debugReadMessage}. */
+export type DebugReadMessageResult<R> =
+  | { ok: true; message: R }
+  | { ok: false; report: string; failure: DecodeFailure };
+
+/**
+ * Convenience debugging wrapper around {@link MessageReader.readMessageDebug}. Decodes `buffer` with
+ * `reader`, returning the decoded message on success. On failure it returns a formatted report
+ * (see {@link formatDecodeDebugReport}) showing exactly what was decoded before the reader threw, so
+ * a test can log the message state at the point of failure.
+ *
+ * Debugging aid only; this does not change deserialization behavior.
+ */
+export function debugReadMessage<R = unknown>(
+  reader: MessageReader,
+  buffer: ArrayBufferView,
+): DebugReadMessageResult<R> {
+  const result = reader.readMessageDebug<R>(buffer);
+  if (result.ok) {
+    return { ok: true, message: result.message };
+  }
+  return { ok: false, report: formatDecodeDebugReport(result), failure: result };
+}

--- a/packages/omgidl-serialization/src/index.ts
+++ b/packages/omgidl-serialization/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./MessageReader";
 export * from "./MessageWriter";
 export * from "./constants";
+export * from "./debugReadMessage";


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 - provides `readMessageDebug` method on class and independently for formatting reports. 

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Adds debug instrumentation which should not affect production use, but will make debugging tests easier since it will now report the decoded parts of the message that preceded the error as well as the error offset. 
