### PR TITLE
Support instance where union is absent and default case has no branch

### DIFF
--- a/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.test.ts
@@ -341,6 +341,25 @@ describe("DeserializationInfoCache", () => {
       b: 0,
     });
   });
+  it("returns discriminator-only default for a union without a default case when the discriminator's natural default matches no case", () => {
+    const unionDefinition: IDLMessageDefinition = {
+      name: "test::MaybeValue",
+      aggregatedKind: "union",
+      switchType: "uint8",
+      cases: [
+        {
+          predicates: [1], // natural default 0 for uint8 matches no case and there is no default
+          type: { name: "value", type: "uint32", isComplex: false },
+        },
+      ],
+    };
+    const deserializationInfoCache = new DeserializationInfoCache([unionDefinition]);
+    const fieldDeserInfo = makeFieldDeserFromComplexDef(unionDefinition, deserializationInfoCache);
+    expect(() => deserializationInfoCache.getFieldDefault(fieldDeserInfo)).not.toThrow();
+    expect(deserializationInfoCache.getFieldDefault(fieldDeserInfo)).toEqual({
+      [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
+    });
+  });
   it("creates correct default for a struct field with optional and non-optional members", () => {
     const unionDefinition: IDLMessageDefinition = {
       name: "test::Message",

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -350,7 +350,7 @@ export class DeserializationInfoCache {
         if (!defaultCase) {
           // No `default:` case and the discriminator's natural default value
           // matches no case label, so no union member is selected (DDS-Xtypes
-          // v1.3 Section 7.2.2.4.4.4, p. 44). The default value of the union is
+          // v1.3 Section 7.2.2.4.4.4, p. 45). The default value of the union is
           // the discriminator alone. This mirrors MessageReader.readUnionType's
           // no-match path so the absent-member default and the present-member
           // read produce the same shape.

--- a/packages/omgidl-serialization/src/DeserializationInfoCache.ts
+++ b/packages/omgidl-serialization/src/DeserializationInfoCache.ts
@@ -346,10 +346,16 @@ export class DeserializationInfoCache {
         const switchValue = switchTypeDefaultGetter() as number | boolean;
 
         defaultCase = unionDef.cases.find((c) => c.predicates.includes(switchValue))?.type;
-        if (!defaultCase) {
-          throw new Error(`Failed to find default case for union ${unionDef.name ?? ""}`);
-        }
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = switchValue;
+        if (!defaultCase) {
+          // No `default:` case and the discriminator's natural default value
+          // matches no case label, so no union member is selected (DDS-Xtypes
+          // v1.3 Section 7.2.2.4.4.4, p. 44). The default value of the union is
+          // the discriminator alone. This mirrors MessageReader.readUnionType's
+          // no-match path so the absent-member default and the present-member
+          // read produce the same shape.
+          return defaultMessage;
+        }
       } else {
         // default exists, default value of switch case type is not needed
         defaultMessage[UNION_DISCRIMINATOR_PROPERTY_KEY] = undefined;

--- a/packages/omgidl-serialization/src/MessageReader.test.ts
+++ b/packages/omgidl-serialization/src/MessageReader.test.ts
@@ -837,6 +837,70 @@ module builtin_interfaces {
     });
   });
 
+  it("default-fills an absent mutable union member with discriminator-only when no case matches and there is no default (XCDR1)", () => {
+    const msgDef = `
+        @mutable
+        union MaybeValue switch (uint8) {
+          case 1:
+            @id(10)
+            uint32 value;
+        };
+        @mutable
+        struct Root {
+            @id(1) uint8 marker;
+            @id(2) MaybeValue maybe;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR_LE });
+    writer.emHeader(true, 1, 1); // marker emHeader
+    writer.uint8(42);
+    // maybe (id 2) omitted -> default-filled
+    writer.sentinelHeader(); // end struct
+
+    const reader = new MessageReader("Root", parseIDL(msgDef));
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      marker: 42,
+      maybe: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
+      },
+    });
+  });
+
+  it("default-fills an absent mutable union member with discriminator-only when no case matches and there is no default (XCDR2)", () => {
+    const msgDef = `
+        @mutable
+        union MaybeValue switch (uint8) {
+          case 1:
+            @id(10)
+            uint32 value;
+        };
+        @mutable
+        struct Root {
+            @id(1) uint8 marker;
+            @id(2) MaybeValue maybe;
+        };
+    `;
+
+    const writer = new CdrWriter({ kind: EncapsulationKind.PL_CDR2_LE });
+    writer.dHeader(4 /* marker emHeader */ + 1 /* marker value */);
+    writer.emHeader(true, 1, 1); // marker emHeader
+    writer.uint8(42);
+    // maybe (id 2) omitted -> default-filled
+
+    const reader = new MessageReader("Root", parseIDL(msgDef));
+    const msgout = reader.readMessage(writer.data);
+
+    expect(msgout).toEqual({
+      marker: 42,
+      maybe: {
+        [UNION_DISCRIMINATOR_PROPERTY_KEY]: 0,
+      },
+    });
+  });
+
   it("skips over body of an XCDR1 mutable union after finding an unknown discriminator", () => {
     const msgDef = `
         @mutable


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 - Fix: Instead of erroring, returns discriminator-only default for a union without a default case when the discriminator's natural default matches no case

### Docs

<!-- Link to a PR or Linear ticket tracking documentation. Write "None" if no documentation changes are needed. -->

### Description

For the case when a union is optional and hasn't been defined, we use the default case for the discriminator type. For uint8 that means using 0. However if the union does not have a branch for that value, then we used to error. This fix allows us to return that default discriminator without a branch. 

<img width="627" height="109" alt="image" src="https://github.com/user-attachments/assets/eab178d4-9008-4e4b-996c-91789b4005d5" />



<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

