### PR TITLE
Bump serialization to 1.2.5

### DIFF
--- a/packages/omgidl-serialization/package.json
+++ b/packages/omgidl-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/omgidl-serialization",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "OMG IDL Schema message serializers and deserializer",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Changelog:
 - Fix error when deserializing missing union with undefined case for default discriminator.