### PR TITLE
Upgrade undici to ^6.27.0 to fix CVE-2026-12151

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
-    "tar": ">=7.5.10"
+    "tar": ">=7.5.10",
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5977,10 +5977,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10/a1715ee4304f58fecd61e0a8c3bd7064435cfbc98b3ec1414dba5e89de97d436b7e88dd094b06ff8440428bf36b56163fc88972118890826039865edf58bdfcf
+"undici@npm:^6.27.0":
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `undici` from `6.26.0` to `6.27.0` to remediate [CVE-2026-12151](https://nvd.nist.gov/vuln/detail/cve-2026-12151) ([GHSA-vxpw-j846-p89q](https://github.com/nodejs/undici/security/advisories/GHSA-vxpw-j846-p89q)).

- `undici` is not a direct dependency; it is pulled in transitively via `node-gyp` (`^6.25.0`), which previously resolved to `6.26.0`.
- Although the NVD description text mentions `>= 6.26.0` as patched, the authoritative undici advisory (and NVD's CPE configuration) list the 6.x line as affected up to but **excluding `6.27.0`**. So `6.26.0` is still vulnerable and the fix requires `>= 6.27.0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6123bcf-4539-4db0-a902-b7599a76d075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6123bcf-4539-4db0-a902-b7599a76d075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

