### PR TITLE
Bump tar to >=7.5.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,21 @@
 {
   "name": "@foxglove/omg-support",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "description": "",
   "license": "MIT",
+  "author": {
+    "name": "Foxglove",
+    "email": "contact@foxglove.dev",
+    "url": "https://foxglove.dev/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/foxglove/omgidl.git"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "clean": "yarn workspaces foreach --all run clean",
     "test": "yarn workspaces foreach --all run test --color",
@@ -21,26 +29,6 @@
     "ros2idl:test": "yarn workspace @foxglove/ros2idl-parser test",
     "ros2idl:build": "yarn workspace @foxglove/ros2idl-parser build"
   },
-  "workspaces": [
-    "packages/*"
-  ],
-  "jest": {
-    "projects": [
-      "packages/omgidl-parser/jest.config.js",
-      "packages/omgidl-serialization/jest.config.js",
-      "packages/ros2idl-parser/jest.config.js"
-    ]
-  },
-  "author": {
-    "name": "Foxglove",
-    "email": "contact@foxglove.dev",
-    "url": "https://foxglove.dev/"
-  },
-  "packageManager": "yarn@4.12.0",
-  "resolutions": {
-    "tar": ">=7.5.10",
-    "undici": "^6.27.0"
-  },
   "devDependencies": {
     "@foxglove/eslint-plugin": "2.1.0",
     "@types/jest": "29.5.14",
@@ -51,5 +39,17 @@
     "ts-jest": "29.4.9",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.2"
-  }
+  },
+  "resolutions": {
+    "tar": ">=7.5.21",
+    "undici": "^6.27.0"
+  },
+  "jest": {
+    "projects": [
+      "packages/omgidl-parser/jest.config.js",
+      "packages/omgidl-serialization/jest.config.js",
+      "packages/ros2idl-parser/jest.config.js"
+    ]
+  },
+  "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5612,16 +5612,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=7.5.10":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:>=7.5.21":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/fb2e77ee858a73936c68e066f4a602d428d6f812e6da0cc1e14a41f99498e4f7fd3535e355fa15157240a5538aa416026cfa6306bb0d1d1c1abf314b1f878e9a
+  checksum: 10/129606384b3c895f422aaca48bf316357be6dc7aa35c1066c3f06c28acfff0be5b356e1b0a0be7c53a7a8945534ac06cec6d8e296d170d8a09c8bff67b29300e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Bumps the Yarn `tar` resolution from `>=7.5.10` to `>=7.5.21` (locks to `7.5.22`) to remediate Dependabot alert [#94](https://github.com/foxglove/omgidl/security/dependabot/94) ([CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw)) and related open `tar` alerts through #98.

Fixes [VIZ-2514](https://linear.app/foxglove/issue/VIZ-2514/remediate-current-medium-cves-in-omgidl)

### Testing
CI covers install/test. No customer-facing behavior change.

Made with [Cursor](https://cursor.com)